### PR TITLE
Add Qt project skeleton with PostgreSQL connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,15 @@ Ce projet consiste à créer une application moderne et innovante de gestion de 
 ## Exemple d’Intégration
 
 * Exemple concret d’intégration Qt/C++ avec PostgreSQL (connexion, requêtes, gestion des erreurs).
+
+## Build and Run
+Ensure Qt 5 (or later) with Widgets and SQL modules is installed.
+
+```
+mkdir build && cd build
+cmake ../src
+make
+./NieSApp
+```
+
+Configure database parameters in `config.ini` before running.

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,6 @@
+[database]
+host=localhost
+port=5432
+name=your_database
+user=your_user
+password=your_password

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.5)
+project(NieSApp LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt5 COMPONENTS Widgets Sql REQUIRED)
+
+add_executable(NieSApp
+    main.cpp
+    DatabaseManager.cpp
+)
+
+target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql)

--- a/src/DatabaseManager.cpp
+++ b/src/DatabaseManager.cpp
@@ -1,0 +1,34 @@
+#include "DatabaseManager.h"
+#include <QSqlError>
+
+DatabaseManager::DatabaseManager(QObject *parent)
+    : QObject(parent), m_settings("config.ini", QSettings::IniFormat)
+{
+    m_db = QSqlDatabase::addDatabase("QPSQL");
+}
+
+bool DatabaseManager::open()
+{
+    m_db.setHostName(m_settings.value("database/host", "localhost").toString());
+    m_db.setDatabaseName(m_settings.value("database/name").toString());
+    m_db.setUserName(m_settings.value("database/user").toString());
+    m_db.setPassword(m_settings.value("database/password").toString());
+    m_db.setPort(m_settings.value("database/port", 5432).toInt());
+
+    if (!m_db.open()) {
+        m_lastError = m_db.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+void DatabaseManager::close()
+{
+    if (m_db.isOpen())
+        m_db.close();
+}
+
+QString DatabaseManager::lastError() const
+{
+    return m_lastError;
+}

--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -1,0 +1,24 @@
+#ifndef DATABASEMANAGER_H
+#define DATABASEMANAGER_H
+
+#include <QObject>
+#include <QSqlDatabase>
+#include <QSettings>
+
+class DatabaseManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DatabaseManager(QObject *parent = nullptr);
+
+    bool open();
+    void close();
+    QString lastError() const;
+
+private:
+    QSqlDatabase m_db;
+    QString m_lastError;
+    QSettings m_settings;
+};
+
+#endif // DATABASEMANAGER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,19 @@
+#include <QApplication>
+#include <QMessageBox>
+#include "DatabaseManager.h"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+
+    DatabaseManager db;
+    if (!db.open()) {
+        QMessageBox::critical(nullptr, "Database Error", db.lastError());
+        return -1;
+    }
+
+    QMessageBox::information(nullptr, "Success", "Connected to database!");
+
+    db.close();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add initial Qt Widgets project in `src/`
- connect to PostgreSQL using a new `DatabaseManager`
- provide example `config.ini`
- document build and run steps in README

## Testing
- `cmake ../src`
- `make`
- `./NieSApp` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_6877c109dd94832886b46cbb29798a42