### PR TITLE
Add Qt Test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
+project(NieS LANGUAGES CXX)
+
+add_subdirectory(src)
+
+enable_testing()
+add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -72,9 +72,21 @@ Ensure Qt 5 (or later) with Widgets and SQL modules is installed.
 
 ```
 mkdir build && cd build
-cmake ../src
+cmake ..
 make
 ./NieSApp
 ```
 
 Configure database parameters in `config.ini` before running.
+
+## Running Tests
+
+The project uses **Qt Test**. Build the test executable and run tests with
+`ctest`:
+
+```
+mkdir build && cd build
+cmake ..
+make
+ctest --output-on-failure
+```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt5 COMPONENTS Test Sql REQUIRED)
+
+set(TEST_SOURCES
+    database_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
+)
+
+add_executable(nies_tests ${TEST_SOURCES})
+
+target_include_directories(nies_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+target_link_libraries(nies_tests Qt5::Test Qt5::Sql)
+
+add_test(NAME NieSTests COMMAND nies_tests)

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -1,0 +1,58 @@
+#include <QtTest>
+#include <QCoreApplication>
+#include "DatabaseManager.h"
+#include <QSqlQuery>
+#include <QSqlRecord>
+
+class DatabaseManagerTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void connectionFailure();
+};
+
+void DatabaseManagerTest::connectionFailure()
+{
+    DatabaseManager db;
+    QVERIFY(!db.open());
+    QVERIFY(!db.lastError().isEmpty());
+    db.close();
+}
+
+class SQLiteQueryTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void simpleSelect();
+};
+
+void SQLiteQueryTest::simpleSelect()
+{
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE", "memdb");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query(db);
+    QVERIFY(query.exec("CREATE TABLE test(id INTEGER PRIMARY KEY, name TEXT);"));
+    QVERIFY(query.exec("INSERT INTO test(name) VALUES('Alice');"));
+    QVERIFY(query.exec("SELECT name FROM test WHERE id=1;"));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toString(), QString("Alice"));
+
+    db.close();
+    QSqlDatabase::removeDatabase("memdb");
+}
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    int status = 0;
+    DatabaseManagerTest dbTest;
+    status |= QTest::qExec(&dbTest, argc, argv);
+    SQLiteQueryTest queryTest;
+    status |= QTest::qExec(&queryTest, argc, argv);
+    return status;
+}
+
+#include "database_test.moc"
+


### PR DESCRIPTION
## Summary
- set up root CMakeLists to build tests
- add tests based on Qt Test for DB connection and SQLite query
- document running tests with CTest

## Testing
- `cmake .. && make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6877c2328f1c8328a2ffc5bde6c3dfb4