### PR TITLE
Add Qt PostgreSQL example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(NieS LANGUAGES CXX)
 
 add_subdirectory(src)
+add_subdirectory(examples/connectdb)
 
 enable_testing()
 add_subdirectory(tests)

--- a/examples/connectdb/CMakeLists.txt
+++ b/examples/connectdb/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(connectdb LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt5 COMPONENTS Sql REQUIRED)
+
+add_executable(connectdb main.cpp)
+
+target_link_libraries(connectdb Qt5::Sql)

--- a/examples/connectdb/README.md
+++ b/examples/connectdb/README.md
@@ -1,0 +1,10 @@
+# ConnectDB Example
+
+This small program demonstrates how to use `QSqlDatabase` to connect to a PostgreSQL server, run a simple query and report errors.
+
+## Run in Qt Creator
+
+1. Open **File > Open File or Project...** and select `examples/connectdb/CMakeLists.txt`.
+2. Configure a build directory when prompted. Make sure Qt's SQL module is available.
+3. Copy `config.ini` from the repository root next to the executable in the build directory or adjust the connection parameters there.
+4. Build and run the `connectdb` target. The Application Output pane will show either the PostgreSQL version string or an error message.

--- a/examples/connectdb/main.cpp
+++ b/examples/connectdb/main.cpp
@@ -1,0 +1,35 @@
+#include <QCoreApplication>
+#include <QSettings>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QDebug>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    QSettings settings("config.ini", QSettings::IniFormat);
+
+    QSqlDatabase db = QSqlDatabase::addDatabase("QPSQL");
+    db.setHostName(settings.value("database/host", "localhost").toString());
+    db.setDatabaseName(settings.value("database/name").toString());
+    db.setUserName(settings.value("database/user").toString());
+    db.setPassword(settings.value("database/password").toString());
+    db.setPort(settings.value("database/port", 5432).toInt());
+
+    if (!db.open()) {
+        qCritical() << "Connection failed:" << db.lastError().text();
+        return 1;
+    }
+
+    QSqlQuery query("SELECT version();");
+    if (query.next()) {
+        qInfo() << "PostgreSQL version:" << query.value(0).toString();
+    } else {
+        qCritical() << "Query error:" << query.lastError().text();
+    }
+
+    db.close();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `examples/connectdb` demonstration
- connect to PostgreSQL, run a query, and print errors
- document running the example from Qt Creator
- include example in root `CMakeLists.txt`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6877c58422708328a0ea04ca7fbde7da