### PR TITLE
Add env vars for DatabaseManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,14 @@ make
 ./NieSApp
 ```
 
-Configure database parameters in `config.ini` before running.
+Configure database parameters in `config.ini` before running. You can also
+override any of the connection settings via environment variables:
+
+- `NIES_DB_HOST` – database host
+- `NIES_DB_PORT` – database port
+- `NIES_DB_NAME` – database name
+- `NIES_DB_USER` – database user
+- `NIES_DB_PASSWORD` – database password
 
 ## Running Tests
 

--- a/src/DatabaseManager.cpp
+++ b/src/DatabaseManager.cpp
@@ -1,5 +1,6 @@
 #include "DatabaseManager.h"
 #include <QSqlError>
+#include <QProcessEnvironment>
 
 DatabaseManager::DatabaseManager(QObject *parent)
     : QObject(parent), m_settings("config.ini", QSettings::IniFormat)
@@ -9,11 +10,29 @@ DatabaseManager::DatabaseManager(QObject *parent)
 
 bool DatabaseManager::open()
 {
-    m_db.setHostName(m_settings.value("database/host", "localhost").toString());
-    m_db.setDatabaseName(m_settings.value("database/name").toString());
-    m_db.setUserName(m_settings.value("database/user").toString());
-    m_db.setPassword(m_settings.value("database/password").toString());
-    m_db.setPort(m_settings.value("database/port", 5432).toInt());
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+    const QString host = env.contains("NIES_DB_HOST")
+            ? env.value("NIES_DB_HOST")
+            : m_settings.value("database/host", "localhost").toString();
+    const QString dbName = env.contains("NIES_DB_NAME")
+            ? env.value("NIES_DB_NAME")
+            : m_settings.value("database/name").toString();
+    const QString user = env.contains("NIES_DB_USER")
+            ? env.value("NIES_DB_USER")
+            : m_settings.value("database/user").toString();
+    const QString password = env.contains("NIES_DB_PASSWORD")
+            ? env.value("NIES_DB_PASSWORD")
+            : m_settings.value("database/password").toString();
+    const int port = env.contains("NIES_DB_PORT")
+            ? env.value("NIES_DB_PORT").toInt()
+            : m_settings.value("database/port", 5432).toInt();
+
+    m_db.setHostName(host);
+    m_db.setDatabaseName(dbName);
+    m_db.setUserName(user);
+    m_db.setPassword(password);
+    m_db.setPort(port);
 
     if (!m_db.open()) {
         m_lastError = m_db.lastError().text();

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -9,14 +9,30 @@ class DatabaseManagerTest : public QObject
     Q_OBJECT
 private slots:
     void connectionFailure();
+    void envPasswordOverride();
 };
 
 void DatabaseManagerTest::connectionFailure()
 {
+    qputenv("NIES_DB_HOST", QByteArray());
+    qputenv("NIES_DB_PORT", QByteArray());
+    qputenv("NIES_DB_NAME", QByteArray());
+    qputenv("NIES_DB_USER", QByteArray());
+    qputenv("NIES_DB_PASSWORD", QByteArray());
     DatabaseManager db;
     QVERIFY(!db.open());
     QVERIFY(!db.lastError().isEmpty());
     db.close();
+}
+
+void DatabaseManagerTest::envPasswordOverride()
+{
+    qputenv("NIES_DB_PASSWORD", QByteArray("dummy"));
+    DatabaseManager db;
+    QVERIFY(!db.open());
+    QVERIFY(!db.lastError().isEmpty());
+    db.close();
+    qputenv("NIES_DB_PASSWORD", QByteArray());
 }
 
 class SQLiteQueryTest : public QObject


### PR DESCRIPTION
## Summary
- support reading DB parameters from `NIES_DB_*` environment variables
- document the variables in README
- clear/set environment variables in database tests

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6877cea891e883289d6930957d8fac23