### PR TITLE
Add CI workflow for building and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ qtbase5-dev qttools5-dev qttools5-dev-tools libqt5sql5 libqt5sql5-psql libpq-dev postgresql
+      - name: Configure
+        run: cmake -B build -S .
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the project and run tests
- install Qt and PostgreSQL dependencies

## Testing
- `cmake .. && make` in local container
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6877d264b56c832892a911c73c49c33a