### PR TITLE
Add UserManager with basic CRUD methods

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Qt5 COMPONENTS Widgets Sql REQUIRED)
 add_executable(NieSApp
     main.cpp
     DatabaseManager.cpp
+    UserManager.cpp
 )
 
 target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql)

--- a/src/UserManager.cpp
+++ b/src/UserManager.cpp
@@ -1,0 +1,66 @@
+#include "UserManager.h"
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QVariant>
+
+UserManager::UserManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool UserManager::createUser(const QString &username, const QString &passwordHash, const QString &role)
+{
+    QSqlQuery query;
+    query.prepare("INSERT INTO users(username, password_hash, role) VALUES(:username, :password_hash, :role)");
+    query.bindValue(":username", username);
+    query.bindValue(":password_hash", passwordHash);
+    query.bindValue(":role", role);
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+bool UserManager::deleteUser(const QString &username)
+{
+    QSqlQuery query;
+    query.prepare("DELETE FROM users WHERE username = :username");
+    query.bindValue(":username", username);
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() > 0;
+}
+
+bool UserManager::updateUserRole(const QString &username, const QString &newRole)
+{
+    QSqlQuery query;
+    query.prepare("UPDATE users SET role = :role WHERE username = :username");
+    query.bindValue(":role", newRole);
+    query.bindValue(":username", username);
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() > 0;
+}
+
+bool UserManager::authenticate(const QString &username, const QString &passwordHash)
+{
+    QSqlQuery query;
+    query.prepare("SELECT id FROM users WHERE username = :username AND password_hash = :password_hash");
+    query.bindValue(":username", username);
+    query.bindValue(":password_hash", passwordHash);
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return false;
+    }
+    return query.next();
+}
+
+QString UserManager::lastError() const
+{
+    return m_lastError;
+}

--- a/src/UserManager.h
+++ b/src/UserManager.h
@@ -1,0 +1,24 @@
+#ifndef USERMANAGER_H
+#define USERMANAGER_H
+
+#include <QObject>
+#include <QString>
+
+class UserManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit UserManager(QObject *parent = nullptr);
+
+    bool createUser(const QString &username, const QString &passwordHash, const QString &role);
+    bool deleteUser(const QString &username);
+    bool updateUserRole(const QString &username, const QString &newRole);
+    bool authenticate(const QString &username, const QString &passwordHash);
+
+    QString lastError() const;
+
+private:
+    QString m_lastError;
+};
+
+#endif // USERMANAGER_H


### PR DESCRIPTION
## Summary
- implement `UserManager` class
- add create/delete/update/authenticate methods using `QSqlQuery`
- compile `UserManager` with the application

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure` *(fails: `startPostgres` requires `postgres` user)*

------
https://chatgpt.com/codex/tasks/task_e_687ad2f8bc688328b6e99b9431e744fc