### PR TITLE
Add inventory & sales management

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ add_executable(NieSApp
     DatabaseManager.cpp
     UserManager.cpp
     ProductManager.cpp
+    InventoryManager.cpp
+    SalesManager.cpp
 )
 
 target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql)

--- a/src/InventoryManager.cpp
+++ b/src/InventoryManager.cpp
@@ -1,0 +1,65 @@
+#include "InventoryManager.h"
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QVariant>
+
+InventoryManager::InventoryManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool InventoryManager::addStock(int productId, int quantity)
+{
+    return updateStock(productId, quantity);
+}
+
+bool InventoryManager::removeStock(int productId, int quantity)
+{
+    return updateStock(productId, -quantity);
+}
+
+bool InventoryManager::updateStock(int productId, int delta)
+{
+    QSqlQuery query;
+    query.prepare("SELECT quantity FROM inventory WHERE product_id = :product_id");
+    query.bindValue(":product_id", productId);
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return false;
+    }
+
+    int current = 0;
+    bool exists = false;
+    if (query.next()) {
+        current = query.value(0).toInt();
+        exists = true;
+    }
+
+    int newQty = current + delta;
+    if (newQty < 0) {
+        m_lastError = QStringLiteral("Insufficient stock");
+        return false;
+    }
+
+    if (exists) {
+        query.prepare("UPDATE inventory SET quantity = :qty, last_update = NOW() WHERE product_id = :product_id");
+        query.bindValue(":qty", newQty);
+        query.bindValue(":product_id", productId);
+    } else {
+        query.prepare("INSERT INTO inventory(product_id, quantity) VALUES(:product_id, :qty)");
+        query.bindValue(":product_id", productId);
+        query.bindValue(":qty", newQty);
+    }
+
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+QString InventoryManager::lastError() const
+{
+    return m_lastError;
+}
+

--- a/src/InventoryManager.h
+++ b/src/InventoryManager.h
@@ -1,0 +1,23 @@
+#ifndef INVENTORYMANAGER_H
+#define INVENTORYMANAGER_H
+
+#include <QObject>
+#include <QString>
+
+class InventoryManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit InventoryManager(QObject *parent = nullptr);
+
+    bool addStock(int productId, int quantity);
+    bool removeStock(int productId, int quantity);
+
+    QString lastError() const;
+
+private:
+    bool updateStock(int productId, int delta);
+    QString m_lastError;
+};
+
+#endif // INVENTORYMANAGER_H

--- a/src/SalesManager.cpp
+++ b/src/SalesManager.cpp
@@ -1,0 +1,67 @@
+#include "SalesManager.h"
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QVariant>
+
+SalesManager::SalesManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool SalesManager::recordSale(int productId, int quantity)
+{
+    QSqlQuery priceQuery;
+    priceQuery.prepare("SELECT price FROM products WHERE id = :id");
+    priceQuery.bindValue(":id", productId);
+    if (!priceQuery.exec() || !priceQuery.next()) {
+        m_lastError = priceQuery.lastError().text();
+        if (m_lastError.isEmpty())
+            m_lastError = QStringLiteral("Product not found");
+        return false;
+    }
+    double price = priceQuery.value(0).toDouble();
+    double total = price * quantity;
+
+    QSqlQuery query;
+    query.prepare("INSERT INTO sales(product_id, quantity, total) VALUES(:pid, :qty, :total)");
+    query.bindValue(":pid", productId);
+    query.bindValue(":qty", quantity);
+    query.bindValue(":total", total);
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return false;
+    }
+
+    if (!m_inventory.removeStock(productId, quantity)) {
+        m_lastError = m_inventory.lastError();
+        return false;
+    }
+
+    return true;
+}
+
+QList<QVariantMap> SalesManager::salesReport()
+{
+    QList<QVariantMap> sales;
+    QSqlQuery query("SELECT id, product_id, quantity, sale_date, total FROM sales ORDER BY sale_date DESC");
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return sales;
+    }
+    while (query.next()) {
+        QVariantMap sale;
+        sale.insert("id", query.value("id"));
+        sale.insert("product_id", query.value("product_id"));
+        sale.insert("quantity", query.value("quantity"));
+        sale.insert("sale_date", query.value("sale_date"));
+        sale.insert("total", query.value("total"));
+        sales.append(sale);
+    }
+    return sales;
+}
+
+QString SalesManager::lastError() const
+{
+    return m_lastError;
+}
+

--- a/src/SalesManager.h
+++ b/src/SalesManager.h
@@ -1,0 +1,25 @@
+#ifndef SALESMANAGER_H
+#define SALESMANAGER_H
+
+#include <QObject>
+#include <QList>
+#include <QVariantMap>
+#include "InventoryManager.h"
+
+class SalesManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SalesManager(QObject *parent = nullptr);
+
+    bool recordSale(int productId, int quantity);
+    QList<QVariantMap> salesReport();
+
+    QString lastError() const;
+
+private:
+    QString m_lastError;
+    InventoryManager m_inventory;
+};
+
+#endif // SALESMANAGER_H


### PR DESCRIPTION
## Summary
- implement `InventoryManager` to handle stock levels
- implement `SalesManager` to record sales and adjust inventory
- build executables with the new managers
- install Qt PostgreSQL plugin during tests

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687ad64251f88328aad4583b98f398b0