### PR TITLE
Add tests for managers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,10 @@ find_package(Qt5 COMPONENTS Test Sql REQUIRED)
 set(TEST_SOURCES
     database_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/ProductManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/InventoryManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/SalesManager.cpp
 )
 
 add_executable(nies_tests ${TEST_SOURCES})

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -1,6 +1,9 @@
 #include <QtTest>
 #include <QCoreApplication>
 #include "DatabaseManager.h"
+#include "UserManager.h"
+#include "ProductManager.h"
+#include "SalesManager.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -139,6 +142,133 @@ void PostgresTest::crudOperations()
     stopPostgres(dir.path());
 }
 
+class UserManagerTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void createUser();
+};
+
+void UserManagerTest::createUser()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec("CREATE TABLE users("
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                       "username TEXT UNIQUE,"
+                       "password_hash TEXT,"
+                       "role TEXT,"
+                       "created_at TEXT)"));
+
+    UserManager um;
+    QVERIFY(um.createUser("alice", "hash", "admin"));
+
+    QVERIFY(query.exec("SELECT username, role FROM users WHERE username='alice'"));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toString(), QString("alice"));
+    QCOMPARE(query.value(1).toString(), QString("admin"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+
+class ProductManagerTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void addProduct();
+};
+
+void ProductManagerTest::addProduct()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec("CREATE TABLE products("
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                       "name TEXT,"
+                       "price REAL,"
+                       "discount REAL DEFAULT 0,"
+                       "created_at TEXT,"
+                       "updated_at TEXT)"));
+
+    ProductManager pm;
+    QVERIFY(pm.addProduct("Widget", 9.99, 1.0));
+
+    QVERIFY(query.exec("SELECT name, price, discount FROM products WHERE id=1"));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toString(), QString("Widget"));
+    QCOMPARE(query.value(1).toDouble(), 9.99);
+    QCOMPARE(query.value(2).toDouble(), 1.0);
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+
+class SalesManagerTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void recordSaleUpdatesInventory();
+};
+
+void SalesManagerTest::recordSaleUpdatesInventory()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec("CREATE TABLE products("
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                       "name TEXT,"
+                       "price REAL,"
+                       "discount REAL DEFAULT 0,"
+                       "created_at TEXT,"
+                       "updated_at TEXT)"));
+    QVERIFY(query.exec("CREATE TABLE inventory("
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                       "product_id INTEGER,"
+                       "quantity INTEGER,"
+                       "last_update TEXT)"));
+    QVERIFY(query.exec("CREATE TABLE sales("
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                       "product_id INTEGER,"
+                       "quantity INTEGER,"
+                       "sale_date TEXT,"
+                       "total REAL)"));
+
+    QVERIFY(query.exec("INSERT INTO products(name, price, discount) VALUES('Thing', 10.0, 0.0)"));
+    int productId = query.lastInsertId().toInt();
+    QVERIFY(query.exec(QString("INSERT INTO inventory(product_id, quantity) VALUES(%1, 10)").arg(productId)));
+
+    SalesManager sm;
+    QVERIFY(sm.recordSale(productId, 3));
+
+    QVERIFY(query.exec("SELECT quantity, total FROM sales WHERE id=1"));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toInt(), 3);
+    QCOMPARE(query.value(1).toDouble(), 30.0);
+
+    QVERIFY(query.exec(QString("SELECT quantity FROM inventory WHERE product_id=%1").arg(productId)));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toInt(), 7);
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+
 int main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
@@ -149,6 +279,12 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&queryTest, argc, argv);
     PostgresTest pgTest;
     status |= QTest::qExec(&pgTest, argc, argv);
+    UserManagerTest userTest;
+    status |= QTest::qExec(&userTest, argc, argv);
+    ProductManagerTest prodTest;
+    status |= QTest::qExec(&prodTest, argc, argv);
+    SalesManagerTest salesTest;
+    status |= QTest::qExec(&salesTest, argc, argv);
     return status;
 }
 


### PR DESCRIPTION
## Summary
- extend tests with `UserManager`, `ProductManager` and `SalesManager`
- ensure new sources are compiled in the test target

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure` *(fails: PostgresTest cannot start and SalesManagerTest fails)*

------
https://chatgpt.com/codex/tasks/task_e_687ad9ba605c8328a1c1b5396ebdafe9