### PR TITLE
Enable discounted sales

### DIFF
--- a/src/InventoryManager.cpp
+++ b/src/InventoryManager.cpp
@@ -41,18 +41,19 @@ bool InventoryManager::updateStock(int productId, int delta)
         return false;
     }
 
+    QSqlQuery modify;
     if (exists) {
-        query.prepare("UPDATE inventory SET quantity = :qty, last_update = NOW() WHERE product_id = :product_id");
-        query.bindValue(":qty", newQty);
-        query.bindValue(":product_id", productId);
+        modify.prepare("UPDATE inventory SET quantity = :qty, last_update = CURRENT_TIMESTAMP WHERE product_id = :product_id");
+        modify.bindValue(":qty", newQty);
+        modify.bindValue(":product_id", productId);
     } else {
-        query.prepare("INSERT INTO inventory(product_id, quantity) VALUES(:product_id, :qty)");
-        query.bindValue(":product_id", productId);
-        query.bindValue(":qty", newQty);
+        modify.prepare("INSERT INTO inventory(product_id, quantity) VALUES(:product_id, :qty)");
+        modify.bindValue(":product_id", productId);
+        modify.bindValue(":qty", newQty);
     }
 
-    if (!query.exec()) {
-        m_lastError = query.lastError().text();
+    if (!modify.exec()) {
+        m_lastError = modify.lastError().text();
         return false;
     }
     return true;

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -249,17 +249,17 @@ void SalesManagerTest::recordSaleUpdatesInventory()
                        "sale_date TEXT,"
                        "total REAL)"));
 
-    QVERIFY(query.exec("INSERT INTO products(name, price, discount) VALUES('Thing', 10.0, 0.0)"));
+    QVERIFY(query.exec("INSERT INTO products(name, price, discount) VALUES('Thing', 10.0, 0.1)"));
     int productId = query.lastInsertId().toInt();
     QVERIFY(query.exec(QString("INSERT INTO inventory(product_id, quantity) VALUES(%1, 10)").arg(productId)));
 
     SalesManager sm;
-    QVERIFY(sm.recordSale(productId, 3));
+    QVERIFY2(sm.recordSale(productId, 3), qPrintable(sm.lastError()));
 
     QVERIFY(query.exec("SELECT quantity, total FROM sales WHERE id=1"));
     QVERIFY(query.next());
     QCOMPARE(query.value(0).toInt(), 3);
-    QCOMPARE(query.value(1).toDouble(), 30.0);
+    QCOMPARE(query.value(1).toDouble(), 27.0);
 
     QVERIFY(query.exec(QString("SELECT quantity FROM inventory WHERE product_id=%1").arg(productId)));
     QVERIFY(query.next());


### PR DESCRIPTION
## Summary
- fetch both price and discount when recording a sale
- compute discounted totals when inserting sales records
- adjust inventory update to use CURRENT_TIMESTAMP
- update unit test for discounted sales

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: PostgresTest due to missing postgres)*

------
https://chatgpt.com/codex/tasks/task_e_687ae8ccadac832887c80979455067b1