### PR TITLE
Support configurable config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ make
 ./NieSApp
 ```
 
-Configure database parameters in `config.ini` before running. You can also
-override any of the connection settings via environment variables:
+Configure database parameters in `config.ini` before running. `DatabaseManager`
+looks for this file next to the executable by default. You may specify a custom
+location with the `NIES_CONFIG_PATH` environment variable or by passing a path
+to the `DatabaseManager` constructor. You can also override individual
+connection settings via environment variables:
 
 - `NIES_DB_HOST` – database host
 - `NIES_DB_PORT` – database port

--- a/examples/connectdb/README.md
+++ b/examples/connectdb/README.md
@@ -6,5 +6,6 @@ This small program demonstrates how to use `QSqlDatabase` to connect to a Postgr
 
 1. Open **File > Open File or Project...** and select `examples/connectdb/CMakeLists.txt`.
 2. Configure a build directory when prompted. Make sure Qt's SQL module is available.
-3. Copy `config.ini` from the repository root next to the executable in the build directory or adjust the connection parameters there.
+3. `DatabaseManager` searches for `config.ini` in the executable's directory. Copy
+   the file there or set `NIES_CONFIG_PATH` to point to a custom location.
 4. Build and run the `connectdb` target. The Application Output pane will show either the PostgreSQL version string or an error message.

--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -4,12 +4,14 @@
 #include <QObject>
 #include <QSqlDatabase>
 #include <QSettings>
+#include <QString>
 
 class DatabaseManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit DatabaseManager(QObject *parent = nullptr);
+    explicit DatabaseManager(const QString &configPath = QString(),
+                             QObject *parent = nullptr);
 
     bool open();
     void close();


### PR DESCRIPTION
## Summary
- make DatabaseManager accept an optional config path and use `NIES_CONFIG_PATH` if set
- look for `config.ini` in the executable directory when no path is provided
- document the new behaviour in README and example
- test using `NIES_CONFIG_PATH` to connect to a temporary PostgreSQL instance

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure` *(fails: startPostgres requires system postgres user)*

------
https://chatgpt.com/codex/tasks/task_e_687aec3b3ce08328945b6f65368f66d7