### PR TITLE
Parameterize Postgres tool paths in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ make
 ctest --output-on-failure
 ```
 
+Some tests start a temporary PostgreSQL server. By default the test suite
+expects `initdb` and `pg_ctl` in `/usr/lib/postgresql/16/bin`. Set the
+`NIES_INITDB_PATH` and `NIES_PG_CTL_PATH` environment variables to override
+these paths. If you cannot run PostgreSQL locally (for example because you lack
+root access), set `NIES_SKIP_PG_TESTS=1` to skip the PostgreSQL dependent tests.
+
 ## Database Initialization
 
 The `database/schema` directory contains SQL scripts for creating the initial

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -78,8 +78,12 @@ private slots:
 
 static bool startPostgres(QTemporaryDir &dir, int port)
 {
-    QString initdb = "/usr/lib/postgresql/16/bin/initdb";
-    QString pgctl = "/usr/lib/postgresql/16/bin/pg_ctl";
+    QString initdb = QString::fromLocal8Bit(qgetenv("NIES_INITDB_PATH"));
+    if (initdb.isEmpty())
+        initdb = "/usr/lib/postgresql/16/bin/initdb";
+    QString pgctl = QString::fromLocal8Bit(qgetenv("NIES_PG_CTL_PATH"));
+    if (pgctl.isEmpty())
+        pgctl = "/usr/lib/postgresql/16/bin/pg_ctl";
 
     QProcess::execute("chown", {"-R", "postgres:postgres", dir.path()});
 
@@ -93,13 +97,17 @@ static bool startPostgres(QTemporaryDir &dir, int port)
 
 static void stopPostgres(const QString &dir)
 {
-    QString pgctl = "/usr/lib/postgresql/16/bin/pg_ctl";
+    QString pgctl = QString::fromLocal8Bit(qgetenv("NIES_PG_CTL_PATH"));
+    if (pgctl.isEmpty())
+        pgctl = "/usr/lib/postgresql/16/bin/pg_ctl";
     QStringList stopArgs{"-u", "postgres", "--", pgctl, "-D", dir, "-m", "fast", "-w", "stop"};
     QProcess::execute("runuser", stopArgs);
 }
 
 void PostgresTest::configPathEnv()
 {
+    if (!qEnvironmentVariableIsEmpty("NIES_SKIP_PG_TESTS"))
+        QSKIP("PostgreSQL tests skipped because NIES_SKIP_PG_TESTS is set");
     QTemporaryDir dbDir;
     QVERIFY(dbDir.isValid());
     int port = 54321 + static_cast<int>(QRandomGenerator::global()->bounded(1000));
@@ -137,6 +145,8 @@ void PostgresTest::configPathEnv()
 
 void PostgresTest::openSuccess()
 {
+    if (!qEnvironmentVariableIsEmpty("NIES_SKIP_PG_TESTS"))
+        QSKIP("PostgreSQL tests skipped because NIES_SKIP_PG_TESTS is set");
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     int port = 55432 + static_cast<int>(QRandomGenerator::global()->bounded(1000));
@@ -157,6 +167,8 @@ void PostgresTest::openSuccess()
 
 void PostgresTest::crudOperations()
 {
+    if (!qEnvironmentVariableIsEmpty("NIES_SKIP_PG_TESTS"))
+        QSKIP("PostgreSQL tests skipped because NIES_SKIP_PG_TESTS is set");
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     int port = 56500 + static_cast<int>(QRandomGenerator::global()->bounded(1000));


### PR DESCRIPTION
## Summary
- allow overriding the paths to `initdb` and `pg_ctl` in tests via environment variables
- provide `NIES_SKIP_PG_TESTS` to skip PostgreSQL tests
- document PostgreSQL test configuration and skipping in README

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure` *(fails without NIES_SKIP_PG_TESTS)*
- `NIES_SKIP_PG_TESTS=1 ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687aefb874b08328a5c0967f88348866