### PR TITLE
Use explicit QtSql includes

### DIFF
--- a/examples/connectdb/main.cpp
+++ b/examples/connectdb/main.cpp
@@ -1,8 +1,8 @@
 #include <QCoreApplication>
 #include <QSettings>
-#include <QSqlDatabase>
-#include <QSqlQuery>
-#include <QSqlError>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlError>
 #include <QDebug>
 
 int main(int argc, char *argv[])

--- a/src/DatabaseManager.cpp
+++ b/src/DatabaseManager.cpp
@@ -1,5 +1,5 @@
 #include "DatabaseManager.h"
-#include <QSqlError>
+#include <QtSql/QSqlError>
 #include <QProcessEnvironment>
 #include <QCoreApplication>
 

--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -2,7 +2,7 @@
 #define DATABASEMANAGER_H
 
 #include <QObject>
-#include <QSqlDatabase>
+#include <QtSql/QSqlDatabase>
 #include <QSettings>
 #include <QString>
 

--- a/src/InventoryManager.cpp
+++ b/src/InventoryManager.cpp
@@ -1,6 +1,6 @@
 #include "InventoryManager.h"
-#include <QSqlQuery>
-#include <QSqlError>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlError>
 #include <QVariant>
 
 InventoryManager::InventoryManager(QObject *parent)

--- a/src/ProductManager.cpp
+++ b/src/ProductManager.cpp
@@ -1,6 +1,6 @@
 #include "ProductManager.h"
-#include <QSqlQuery>
-#include <QSqlError>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlError>
 #include <QVariant>
 
 ProductManager::ProductManager(QObject *parent)

--- a/src/SalesManager.cpp
+++ b/src/SalesManager.cpp
@@ -1,6 +1,6 @@
 #include "SalesManager.h"
-#include <QSqlQuery>
-#include <QSqlError>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlError>
 #include <QVariant>
 
 SalesManager::SalesManager(QObject *parent)

--- a/src/UserManager.cpp
+++ b/src/UserManager.cpp
@@ -1,6 +1,6 @@
 #include "UserManager.h"
-#include <QSqlQuery>
-#include <QSqlError>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlError>
 #include <QVariant>
 
 UserManager::UserManager(QObject *parent)

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -7,8 +7,8 @@
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
-#include <QSqlQuery>
-#include <QSqlRecord>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlRecord>
 #include <QFile>
 #include <QTextStream>
 


### PR DESCRIPTION
## Summary
- reference `QtSql` module explicitly in source and example
- fix includes in tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure` *(fails: startPostgres returned FALSE)*

------
https://chatgpt.com/codex/tasks/task_e_687b0b2215d48328ae923845c509263a