### PR TITLE
Add salted password storage

### DIFF
--- a/database/schema/users.sql
+++ b/database/schema/users.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     username VARCHAR(50) NOT NULL UNIQUE,
     password_hash TEXT NOT NULL,
+    password_salt TEXT NOT NULL,
     role VARCHAR(20) NOT NULL DEFAULT 'seller',
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/src/UserManager.h
+++ b/src/UserManager.h
@@ -10,10 +10,10 @@ class UserManager : public QObject
 public:
     explicit UserManager(QObject *parent = nullptr);
 
-    bool createUser(const QString &username, const QString &passwordHash, const QString &role);
+    bool createUser(const QString &username, const QString &password, const QString &role);
     bool deleteUser(const QString &username);
     bool updateUserRole(const QString &username, const QString &newRole);
-    bool authenticate(const QString &username, const QString &passwordHash);
+    bool authenticate(const QString &username, const QString &password);
 
     QString lastError() const;
 


### PR DESCRIPTION
## Summary
- store a salt alongside password hashes
- hash `salt + password` in `UserManager`
- verify passwords using the stored salt
- test new behaviour

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687bb6fe7e008328812b7c5f8568585a