### PR TITLE
Add error message on wrong password

### DIFF
--- a/src/UserManager.cpp
+++ b/src/UserManager.cpp
@@ -71,7 +71,12 @@ bool UserManager::authenticate(const QString &username, const QString &password)
     const QString storedHash = query.value(0).toString();
     const QString salt = query.value(1).toString();
     const QByteArray computed = QCryptographicHash::hash((salt + password).toUtf8(), QCryptographicHash::Sha256).toHex();
-    return storedHash == QString(computed);
+
+    if (storedHash != QString(computed)) {
+        m_lastError = QStringLiteral("Incorrect password");
+        return false;
+    }
+    return true;
 }
 
 QString UserManager::lastError() const

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -157,6 +157,7 @@ void UserManagerTest::authenticateUser()
 
     QVERIFY(um.authenticate("bob", "mypwd"));
     QVERIFY(!um.authenticate("bob", "wrong"));
+    QCOMPARE(um.lastError(), QString("Incorrect password"));
 
     db.close();
     QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);


### PR DESCRIPTION
## Summary
- report an "Incorrect password" error when authentication fails due to hash mismatch
- check that failed `authenticate` sets `lastError` correctly in tests

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687bc061725c832899783bbd79840e75