### PR TITLE
Add login dialog with tests

### DIFF
--- a/NieSApp.pro
+++ b/NieSApp.pro
@@ -9,14 +9,18 @@ SOURCES += \
     src/UserManager.cpp \
     src/ProductManager.cpp \
     src/InventoryManager.cpp \
-    src/SalesManager.cpp
+    src/SalesManager.cpp \
+    src/login/LoginDialog.cpp \
+    src/login/MainWindow.cpp
 
 HEADERS += \
     src/DatabaseManager.h \
     src/UserManager.h \
     src/ProductManager.h \
     src/InventoryManager.h \
-    src/SalesManager.h
+    src/SalesManager.h \
+    src/login/LoginDialog.h \
+    src/login/MainWindow.h
 
 # Include config file for convenience
 OTHER_FILES += config.ini

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,9 @@ add_executable(NieSApp
     ProductManager.cpp
     InventoryManager.cpp
     SalesManager.cpp
+    login/LoginDialog.cpp
+    login/MainWindow.cpp
 )
 
 target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql)
+target_include_directories(NieSApp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/login/LoginDialog.cpp
+++ b/src/login/LoginDialog.cpp
@@ -1,0 +1,50 @@
+#include "LoginDialog.h"
+#include "UserManager.h"
+#include <QLineEdit>
+#include <QPushButton>
+#include <QFormLayout>
+#include <QVBoxLayout>
+#include <QMessageBox>
+
+LoginDialog::LoginDialog(UserManager *userManager, QWidget *parent, bool showErrors)
+    : QDialog(parent),
+      m_userManager(userManager),
+      m_showErrors(showErrors)
+{
+    setWindowTitle(tr("Login"));
+
+    m_usernameEdit = new QLineEdit(this);
+    m_passwordEdit = new QLineEdit(this);
+    m_passwordEdit->setEchoMode(QLineEdit::Password);
+
+    m_loginButton = new QPushButton(tr("Login"), this);
+    connect(m_loginButton, &QPushButton::clicked, this, &LoginDialog::onLoginClicked);
+
+    QFormLayout *form = new QFormLayout;
+    form->addRow(tr("Username"), m_usernameEdit);
+    form->addRow(tr("Password"), m_passwordEdit);
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addLayout(form);
+    layout->addWidget(m_loginButton);
+}
+
+void LoginDialog::onLoginClicked()
+{
+    attemptLogin(m_usernameEdit->text(), m_passwordEdit->text());
+}
+
+bool LoginDialog::attemptLogin(const QString &username, const QString &password)
+{
+    if (m_userManager->authenticate(username, password)) {
+        emit loginSuccessful();
+        accept();
+        return true;
+    }
+
+    if (m_showErrors) {
+        QMessageBox::warning(this, tr("Login failed"), m_userManager->lastError());
+    }
+    return false;
+}
+

--- a/src/login/LoginDialog.h
+++ b/src/login/LoginDialog.h
@@ -1,0 +1,32 @@
+#ifndef LOGINDIALOG_H
+#define LOGINDIALOG_H
+
+#include <QDialog>
+
+class QLineEdit;
+class QPushButton;
+class UserManager;
+
+class LoginDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit LoginDialog(UserManager *userManager, QWidget *parent = nullptr, bool showErrors = true);
+
+    bool attemptLogin(const QString &username, const QString &password);
+
+signals:
+    void loginSuccessful();
+
+private slots:
+    void onLoginClicked();
+
+private:
+    UserManager *m_userManager;
+    QLineEdit *m_usernameEdit;
+    QLineEdit *m_passwordEdit;
+    QPushButton *m_loginButton;
+    bool m_showErrors;
+};
+
+#endif // LOGINDIALOG_H

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -1,0 +1,8 @@
+#include "MainWindow.h"
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+{
+    setWindowTitle(tr("NieS"));
+}
+

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -1,0 +1,13 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+};
+
+#endif // MAINWINDOW_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,9 @@
 #include <QApplication>
 #include <QMessageBox>
 #include "DatabaseManager.h"
+#include "UserManager.h"
+#include "login/LoginDialog.h"
+#include "login/MainWindow.h"
 
 int main(int argc, char *argv[])
 {
@@ -12,8 +15,17 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    QMessageBox::information(nullptr, "Success", "Connected to database!");
+    UserManager userManager;
+    LoginDialog login(&userManager);
+    if (login.exec() != QDialog::Accepted) {
+        db.close();
+        return 0;
+    }
+
+    MainWindow mainWin;
+    mainWin.show();
+    int ret = app.exec();
 
     db.close();
-    return 0;
+    return ret;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,21 +2,24 @@ cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5 COMPONENTS Test Sql REQUIRED)
+find_package(Qt5 COMPONENTS Test Sql Widgets REQUIRED)
 
 set(TEST_SOURCES
     database_test.cpp
+    login_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
     ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
     ${CMAKE_SOURCE_DIR}/src/ProductManager.cpp
     ${CMAKE_SOURCE_DIR}/src/InventoryManager.cpp
     ${CMAKE_SOURCE_DIR}/src/SalesManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/login/LoginDialog.cpp
+    ${CMAKE_SOURCE_DIR}/src/login/MainWindow.cpp
 )
 
 add_executable(nies_tests ${TEST_SOURCES})
 
 target_include_directories(nies_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
-target_link_libraries(nies_tests Qt5::Test Qt5::Sql)
+target_link_libraries(nies_tests Qt5::Test Qt5::Sql Qt5::Widgets)
 
 add_test(NAME NieSTests COMMAND nies_tests)

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -1,9 +1,10 @@
 #include <QtTest>
-#include <QCoreApplication>
+#include <QApplication>
 #include "DatabaseManager.h"
 #include "UserManager.h"
 #include "ProductManager.h"
 #include "SalesManager.h"
+#include "login_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -536,7 +537,8 @@ void InventoryManagerTest::removeStockInsufficient()
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication app(argc, argv);
+    qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
+    QApplication app(argc, argv);
     int status = 0;
     DatabaseManagerTest dbTest;
     status |= QTest::qExec(&dbTest, argc, argv);
@@ -551,6 +553,8 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&salesTest, argc, argv);
     InventoryManagerTest invTest;
     status |= QTest::qExec(&invTest, argc, argv);
+    LoginDialogTest loginTest;
+    status |= QTest::qExec(&loginTest, argc, argv);
     return status;
 }
 

--- a/tests/login_test.cpp
+++ b/tests/login_test.cpp
@@ -1,0 +1,64 @@
+#include <QtTest>
+#include <QApplication>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+#include "login/LoginDialog.h"
+#include "UserManager.h"
+#include "login_test.h"
+
+void LoginDialogTest::invalidCredentials()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec(
+               "CREATE TABLE users("
+               "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+               "username TEXT UNIQUE,"
+               "password_hash TEXT,"
+               "password_salt TEXT,"
+               "role TEXT,"
+               "created_at TEXT)"));
+
+    UserManager um;
+    QVERIFY(um.createUser("user", "pass", "role"));
+
+    LoginDialog dlg(&um, nullptr, false);
+    QVERIFY(!dlg.attemptLogin("user", "wrong"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+
+void LoginDialogTest::validCredentials()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec(
+               "CREATE TABLE users("
+               "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+               "username TEXT UNIQUE,"
+               "password_hash TEXT,"
+               "password_salt TEXT,"
+               "role TEXT,"
+               "created_at TEXT)"));
+
+    UserManager um;
+    QVERIFY(um.createUser("bob", "secret", "role"));
+
+    LoginDialog dlg(&um, nullptr, false);
+    QVERIFY(dlg.attemptLogin("bob", "secret"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+

--- a/tests/login_test.h
+++ b/tests/login_test.h
@@ -1,0 +1,14 @@
+#ifndef LOGIN_TEST_H
+#define LOGIN_TEST_H
+
+#include <QObject>
+
+class LoginDialogTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void invalidCredentials();
+    void validCredentials();
+};
+
+#endif // LOGIN_TEST_H


### PR DESCRIPTION
## Summary
- implement `LoginDialog` widget and `MainWindow` placeholder
- integrate login flow in `main.cpp`
- compile new widgets in CMake/qmake
- add Qt offscreen testing and new login tests

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687bc7851a1c8328b0504234bb848f73