### PR TITLE
Track database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ require a running database server.
 ## Database Initialization
 
 The `database/schema` directory contains SQL scripts for creating the initial
-tables (`users`, `products`, `inventory` and `sales`). After creating your
+tables (`users`, `products`, `inventory`, `sales` and `schema_migrations`). After creating your
 MySQL database and editing `config.ini`, initialize the schema with:
 
 ```sh
@@ -114,7 +114,9 @@ mysql -u <your_user> <your_database> < database/schema/init.sql
 ```
 
 Optional migration scripts live in `database/migrations`. You can apply them with
-`database/migrate.sh` which relies on the `mysql` command line tool:
+`database/migrate.sh`. The script relies on the `mysql` command line tool and
+records each successfully applied file name in the `schema_migrations` table so
+subsequent runs skip migrations that were already executed:
 
 ```sh
 ./database/migrate.sh <your_database> <your_user>

--- a/database/migrate.sh
+++ b/database/migrate.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # Simple migration runner
 # Usage: ./database/migrate.sh DBNAME USERNAME
+#
+# Applies all SQL files in database/migrations and records each applied
+# filename in the `schema_migrations` table. Existing entries are skipped
+# so running the script multiple times is safe.
 
 DB="$1"
 USER="$2"
@@ -11,12 +15,22 @@ if [ -z "$DB" ] || [ -z "$USER" ]; then
     exit 1
 fi
 
+mysql -u "$USER" "$DB" -e "CREATE TABLE IF NOT EXISTS schema_migrations (filename VARCHAR(255) PRIMARY KEY)" || exit 1
+
 for file in "$DIR"/migrations/*.sql; do
     [ -e "$file" ] || continue
+    base="$(basename "$file")"
+    already=$(mysql -N -s -u "$USER" "$DB" -e "SELECT 1 FROM schema_migrations WHERE filename='$base' LIMIT 1;")
+    if [ "$already" = "1" ]; then
+        echo "Skipping $base (already applied)"
+        continue
+    fi
+
     echo "Applying $file"
     mysql -u "$USER" "$DB" < "$file"
     if [ $? -ne 0 ]; then
         echo "Error applying $file"
         exit 1
     fi
+    mysql -u "$USER" "$DB" -e "INSERT INTO schema_migrations (filename) VALUES ('$base')" || exit 1
 done

--- a/database/schema/init.sql
+++ b/database/schema/init.sql
@@ -32,3 +32,7 @@ CREATE TABLE IF NOT EXISTS sales (
     total DECIMAL(10,2) NOT NULL,
     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT
 );
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename VARCHAR(255) PRIMARY KEY
+);

--- a/database/schema/schema_migrations.sql
+++ b/database/schema/schema_migrations.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename VARCHAR(255) PRIMARY KEY
+);


### PR DESCRIPTION
## Summary
- add `schema_migrations` table to base schema
- track applied migrations in `migrate.sh`
- document migration tracking in README

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687bcb353c6083289221a3a2d13046f2