### PR TITLE
Add product management window with tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(NieSApp
     DatabaseManager.cpp
     UserManager.cpp
     ProductManager.cpp
+    products/ProductWindow.cpp
     InventoryManager.cpp
     SalesManager.cpp
     login/LoginDialog.cpp

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -1,8 +1,26 @@
 #include "MainWindow.h"
+#include "products/ProductWindow.h"
+#include "ProductManager.h"
+#include <QMenuBar>
+#include <QMenu>
+#include <QAction>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
 {
     setWindowTitle(tr("NieS"));
+
+    QMenu *prodMenu = menuBar()->addMenu(tr("Products"));
+    QAction *manageAct = prodMenu->addAction(tr("Manage Products"));
+    connect(manageAct, &QAction::triggered, this, &MainWindow::openProducts);
+}
+
+void MainWindow::openProducts()
+{
+    if (!m_productWindow)
+        m_productWindow = new ProductWindow(new ProductManager(this), this);
+    m_productWindow->show();
+    m_productWindow->raise();
+    m_productWindow->activateWindow();
 }
 

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -3,11 +3,19 @@
 
 #include <QMainWindow>
 
+class ProductWindow;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
 public:
     explicit MainWindow(QWidget *parent = nullptr);
+
+private slots:
+    void openProducts();
+
+private:
+    ProductWindow *m_productWindow = nullptr;
 };
 
 #endif // MAINWINDOW_H

--- a/src/products/ProductWindow.cpp
+++ b/src/products/ProductWindow.cpp
@@ -1,0 +1,117 @@
+#include "ProductWindow.h"
+#include "ProductManager.h"
+
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QDoubleSpinBox>
+#include <QPushButton>
+#include <QMessageBox>
+
+ProductWindow::ProductWindow(ProductManager *pm, QWidget *parent)
+    : QWidget(parent),
+      m_pm(pm)
+{
+    setWindowTitle(tr("Products"));
+
+    m_table = new QTableWidget(this);
+    m_table->setObjectName("productTable");
+    m_table->setColumnCount(4);
+    m_table->setHorizontalHeaderLabels({tr("ID"), tr("Name"), tr("Price"), tr("Discount")});
+    m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+
+    m_nameEdit = new QLineEdit(this);
+    m_nameEdit->setObjectName("nameEdit");
+    m_priceEdit = new QDoubleSpinBox(this);
+    m_priceEdit->setObjectName("priceEdit");
+    m_priceEdit->setMaximum(999999);
+    m_discountEdit = new QDoubleSpinBox(this);
+    m_discountEdit->setObjectName("discountEdit");
+    m_discountEdit->setMaximum(100000);
+
+    m_addBtn = new QPushButton(tr("Add"), this);
+    m_editBtn = new QPushButton(tr("Edit"), this);
+    m_deleteBtn = new QPushButton(tr("Delete"), this);
+
+    connect(m_addBtn, &QPushButton::clicked, this, &ProductWindow::onAdd);
+    connect(m_editBtn, &QPushButton::clicked, this, &ProductWindow::onEdit);
+    connect(m_deleteBtn, &QPushButton::clicked, this, &ProductWindow::onDelete);
+
+    QFormLayout *form = new QFormLayout;
+    form->addRow(tr("Name"), m_nameEdit);
+    form->addRow(tr("Price"), m_priceEdit);
+    form->addRow(tr("Discount"), m_discountEdit);
+
+    QHBoxLayout *buttons = new QHBoxLayout;
+    buttons->addWidget(m_addBtn);
+    buttons->addWidget(m_editBtn);
+    buttons->addWidget(m_deleteBtn);
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addWidget(m_table);
+    layout->addLayout(form);
+    layout->addLayout(buttons);
+
+    loadProducts();
+}
+
+void ProductWindow::loadProducts()
+{
+    m_table->setRowCount(0);
+    const QList<QVariantMap> products = m_pm->listProducts();
+    for (int i = 0; i < products.size(); ++i) {
+        m_table->insertRow(i);
+        const QVariantMap &p = products[i];
+        m_table->setItem(i, 0, new QTableWidgetItem(p.value("id").toString()));
+        m_table->setItem(i, 1, new QTableWidgetItem(p.value("name").toString()));
+        m_table->setItem(i, 2, new QTableWidgetItem(QString::number(p.value("price").toDouble())));
+        m_table->setItem(i, 3, new QTableWidgetItem(QString::number(p.value("discount").toDouble())));
+    }
+    if (m_table->rowCount() > 0)
+        m_table->selectRow(0);
+}
+
+void ProductWindow::onAdd()
+{
+    if (m_nameEdit->text().isEmpty())
+        return;
+    if (!m_pm->addProduct(m_nameEdit->text(), m_priceEdit->value(), m_discountEdit->value())) {
+        QMessageBox::warning(this, tr("Error"), m_pm->lastError());
+        return;
+    }
+    m_nameEdit->clear();
+    m_priceEdit->setValue(0);
+    m_discountEdit->setValue(0);
+    loadProducts();
+}
+
+void ProductWindow::onEdit()
+{
+    int row = m_table->currentRow();
+    if (row < 0)
+        return;
+    int id = m_table->item(row, 0)->text().toInt();
+    if (!m_pm->updateProduct(id, m_nameEdit->text(), m_priceEdit->value(), m_discountEdit->value())) {
+        QMessageBox::warning(this, tr("Error"), m_pm->lastError());
+        return;
+    }
+    loadProducts();
+}
+
+void ProductWindow::onDelete()
+{
+    int row = m_table->currentRow();
+    if (row < 0)
+        return;
+    int id = m_table->item(row, 0)->text().toInt();
+    if (!m_pm->deleteProduct(id)) {
+        QMessageBox::warning(this, tr("Error"), m_pm->lastError());
+        return;
+    }
+    loadProducts();
+}
+

--- a/src/products/ProductWindow.h
+++ b/src/products/ProductWindow.h
@@ -1,0 +1,37 @@
+#ifndef PRODUCTWINDOW_H
+#define PRODUCTWINDOW_H
+
+#include <QWidget>
+
+class QTableWidget;
+class QLineEdit;
+class QDoubleSpinBox;
+class QPushButton;
+class ProductManager;
+
+class ProductWindow : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ProductWindow(ProductManager *pm, QWidget *parent = nullptr);
+
+public slots:
+    void loadProducts();
+
+private slots:
+    void onAdd();
+    void onEdit();
+    void onDelete();
+
+private:
+    ProductManager *m_pm;
+    QTableWidget *m_table;
+    QLineEdit *m_nameEdit;
+    QDoubleSpinBox *m_priceEdit;
+    QDoubleSpinBox *m_discountEdit;
+    QPushButton *m_addBtn;
+    QPushButton *m_editBtn;
+    QPushButton *m_deleteBtn;
+};
+
+#endif // PRODUCTWINDOW_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,9 +7,11 @@ find_package(Qt5 COMPONENTS Test Sql Widgets REQUIRED)
 set(TEST_SOURCES
     database_test.cpp
     login_test.cpp
+    product_window_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
     ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
     ${CMAKE_SOURCE_DIR}/src/ProductManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/products/ProductWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/InventoryManager.cpp
     ${CMAKE_SOURCE_DIR}/src/SalesManager.cpp
     ${CMAKE_SOURCE_DIR}/src/login/LoginDialog.cpp

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -5,6 +5,7 @@
 #include "ProductManager.h"
 #include "SalesManager.h"
 #include "login_test.h"
+#include "product_window_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -667,6 +668,8 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&offlineTest, argc, argv);
     LoginDialogTest loginTest;
     status |= QTest::qExec(&loginTest, argc, argv);
+    ProductWindowTest productWindowTest;
+    status |= QTest::qExec(&productWindowTest, argc, argv);
     return status;
 }
 

--- a/tests/product_window_test.cpp
+++ b/tests/product_window_test.cpp
@@ -1,0 +1,54 @@
+#include <QtTest>
+#include <QApplication>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+#include <QLineEdit>
+#include <QDoubleSpinBox>
+#include <QTableWidget>
+
+#include "products/ProductWindow.h"
+#include "ProductManager.h"
+#include "product_window_test.h"
+
+void ProductWindowTest::addProductUI()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec("CREATE TABLE products("
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                       "name TEXT,"
+                       "price REAL,"
+                       "discount REAL DEFAULT 0,"
+                       "created_at TEXT,"
+                       "updated_at TEXT)"));
+
+    ProductManager pm;
+    ProductWindow w(&pm);
+    w.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&w));
+
+    auto nameEdit = w.findChild<QLineEdit*>("nameEdit");
+    auto priceEdit = w.findChild<QDoubleSpinBox*>("priceEdit");
+    auto discountEdit = w.findChild<QDoubleSpinBox*>("discountEdit");
+    QVERIFY(nameEdit && priceEdit && discountEdit);
+
+    nameEdit->setText("TestItem");
+    priceEdit->setValue(5.5);
+    discountEdit->setValue(0.5);
+
+    QVERIFY(QMetaObject::invokeMethod(&w, "onAdd", Qt::DirectConnection));
+
+    auto table = w.findChild<QTableWidget*>("productTable");
+    QVERIFY(table);
+    QCOMPARE(table->rowCount(), 1);
+    QCOMPARE(table->item(0,1)->text(), QString("TestItem"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+

--- a/tests/product_window_test.h
+++ b/tests/product_window_test.h
@@ -1,0 +1,13 @@
+#ifndef PRODUCT_WINDOW_TEST_H
+#define PRODUCT_WINDOW_TEST_H
+
+#include <QObject>
+
+class ProductWindowTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void addProductUI();
+};
+
+#endif // PRODUCT_WINDOW_TEST_H


### PR DESCRIPTION
## Summary
- introduce `ProductWindow` widget to list and manage products
- hook product window into `MainWindow` via a menu action
- build and test new window through Qt test case

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687bd9798acc83288107304d332c14ec