### PR TITLE
Add POSWindow with sale tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(NieSApp
     products/ProductWindow.cpp
     InventoryManager.cpp
     SalesManager.cpp
+    sales/POSWindow.cpp
     login/LoginDialog.cpp
     login/MainWindow.cpp
 )

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -1,6 +1,8 @@
 #include "MainWindow.h"
 #include "products/ProductWindow.h"
+#include "sales/POSWindow.h"
 #include "ProductManager.h"
+#include "SalesManager.h"
 #include <QMenuBar>
 #include <QMenu>
 #include <QAction>
@@ -13,6 +15,10 @@ MainWindow::MainWindow(QWidget *parent)
     QMenu *prodMenu = menuBar()->addMenu(tr("Products"));
     QAction *manageAct = prodMenu->addAction(tr("Manage Products"));
     connect(manageAct, &QAction::triggered, this, &MainWindow::openProducts);
+
+    QMenu *salesMenu = menuBar()->addMenu(tr("Sales"));
+    QAction *posAct = salesMenu->addAction(tr("Point of Sale"));
+    connect(posAct, &QAction::triggered, this, &MainWindow::openPOS);
 }
 
 void MainWindow::openProducts()
@@ -22,5 +28,14 @@ void MainWindow::openProducts()
     m_productWindow->show();
     m_productWindow->raise();
     m_productWindow->activateWindow();
+}
+
+void MainWindow::openPOS()
+{
+    if (!m_posWindow)
+        m_posWindow = new POSWindow(new ProductManager(this), new SalesManager(this), this);
+    m_posWindow->show();
+    m_posWindow->raise();
+    m_posWindow->activateWindow();
 }
 

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 
 class ProductWindow;
+class POSWindow;
 
 class MainWindow : public QMainWindow
 {
@@ -13,9 +14,11 @@ public:
 
 private slots:
     void openProducts();
+    void openPOS();
 
 private:
     ProductWindow *m_productWindow = nullptr;
+    POSWindow *m_posWindow = nullptr;
 };
 
 #endif // MAINWINDOW_H

--- a/src/sales/POSWindow.cpp
+++ b/src/sales/POSWindow.cpp
@@ -1,0 +1,66 @@
+#include "POSWindow.h"
+#include "ProductManager.h"
+#include "SalesManager.h"
+
+#include <QComboBox>
+#include <QSpinBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QMessageBox>
+
+POSWindow::POSWindow(ProductManager *pm, SalesManager *sm, QWidget *parent)
+    : QWidget(parent),
+      m_pm(pm),
+      m_sm(sm)
+{
+    setWindowTitle(tr("Point of Sale"));
+
+    m_productBox = new QComboBox(this);
+    m_productBox->setObjectName("productBox");
+
+    m_qtySpin = new QSpinBox(this);
+    m_qtySpin->setObjectName("qtySpin");
+    m_qtySpin->setMinimum(1);
+    m_qtySpin->setMaximum(1000000);
+
+    m_sellBtn = new QPushButton(tr("Sell"), this);
+    m_sellBtn->setObjectName("sellBtn");
+    connect(m_sellBtn, &QPushButton::clicked, this, &POSWindow::onSell);
+
+    QFormLayout *form = new QFormLayout;
+    form->addRow(tr("Product"), m_productBox);
+    form->addRow(tr("Quantity"), m_qtySpin);
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addLayout(form);
+    layout->addWidget(m_sellBtn);
+
+    loadProducts();
+}
+
+void POSWindow::loadProducts()
+{
+    m_productBox->clear();
+    const QList<QVariantMap> products = m_pm->listProducts();
+    for (const QVariantMap &p : products) {
+        QString label = QString("%1 (%2)")
+                             .arg(p.value("name").toString())
+                             .arg(p.value("price").toDouble());
+        m_productBox->addItem(label, p.value("id"));
+    }
+}
+
+void POSWindow::onSell()
+{
+    int productId = m_productBox->currentData().toInt();
+    int qty = m_qtySpin->value();
+    if (productId <= 0 || qty <= 0)
+        return;
+    if (!m_sm->recordSale(productId, qty)) {
+        QMessageBox::warning(this, tr("Error"), m_sm->lastError());
+        return;
+    }
+    m_qtySpin->setValue(1);
+}
+

--- a/src/sales/POSWindow.h
+++ b/src/sales/POSWindow.h
@@ -1,0 +1,32 @@
+#ifndef POSWINDOW_H
+#define POSWINDOW_H
+
+#include <QWidget>
+
+class QComboBox;
+class QSpinBox;
+class QPushButton;
+class ProductManager;
+class SalesManager;
+
+class POSWindow : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit POSWindow(ProductManager *pm, SalesManager *sm, QWidget *parent = nullptr);
+
+public slots:
+    void loadProducts();
+
+private slots:
+    void onSell();
+
+private:
+    ProductManager *m_pm;
+    SalesManager *m_sm;
+    QComboBox *m_productBox;
+    QSpinBox *m_qtySpin;
+    QPushButton *m_sellBtn;
+};
+
+#endif // POSWINDOW_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,10 +8,12 @@ set(TEST_SOURCES
     database_test.cpp
     login_test.cpp
     product_window_test.cpp
+    pos_window_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
     ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
     ${CMAKE_SOURCE_DIR}/src/ProductManager.cpp
     ${CMAKE_SOURCE_DIR}/src/products/ProductWindow.cpp
+    ${CMAKE_SOURCE_DIR}/src/sales/POSWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/InventoryManager.cpp
     ${CMAKE_SOURCE_DIR}/src/SalesManager.cpp
     ${CMAKE_SOURCE_DIR}/src/login/LoginDialog.cpp

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -6,6 +6,7 @@
 #include "SalesManager.h"
 #include "login_test.h"
 #include "product_window_test.h"
+#include "pos_window_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -670,6 +671,8 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&loginTest, argc, argv);
     ProductWindowTest productWindowTest;
     status |= QTest::qExec(&productWindowTest, argc, argv);
+    POSWindowTest posWindowTest;
+    status |= QTest::qExec(&posWindowTest, argc, argv);
     return status;
 }
 

--- a/tests/pos_window_test.cpp
+++ b/tests/pos_window_test.cpp
@@ -1,0 +1,63 @@
+#include <QtTest>
+#include <QApplication>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+#include <QSpinBox>
+
+#include "sales/POSWindow.h"
+#include "ProductManager.h"
+#include "SalesManager.h"
+#include "pos_window_test.h"
+
+void POSWindowTest::sellItemUpdatesInventory()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec("CREATE TABLE products("\
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"\
+                       "name TEXT,"\
+                       "price REAL,"\
+                       "discount REAL DEFAULT 0,"\
+                       "created_at TEXT,"\
+                       "updated_at TEXT)"));
+    QVERIFY(query.exec("CREATE TABLE inventory("\
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"\
+                       "product_id INTEGER,"\
+                       "quantity INTEGER,"\
+                       "last_update TEXT)"));
+    QVERIFY(query.exec("CREATE TABLE sales("\
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"\
+                       "product_id INTEGER,"\
+                       "quantity INTEGER,"\
+                       "sale_date TEXT,"\
+                       "total REAL)"));
+
+    QVERIFY(query.exec("INSERT INTO products(name, price, discount) VALUES('Item', 2.0, 0.0)"));
+    int productId = query.lastInsertId().toInt();
+    QVERIFY(query.exec(QString("INSERT INTO inventory(product_id, quantity) VALUES(%1, 5)").arg(productId)));
+
+    ProductManager pm;
+    SalesManager sm;
+    POSWindow w(&pm, &sm);
+    w.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&w));
+
+    auto qtySpin = w.findChild<QSpinBox*>("qtySpin");
+    QVERIFY(qtySpin);
+    qtySpin->setValue(3);
+
+    QVERIFY(QMetaObject::invokeMethod(&w, "onSell", Qt::DirectConnection));
+
+    QVERIFY(query.exec(QString("SELECT quantity FROM inventory WHERE product_id=%1").arg(productId)));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toInt(), 2);
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+

--- a/tests/pos_window_test.h
+++ b/tests/pos_window_test.h
@@ -1,0 +1,13 @@
+#ifndef POS_WINDOW_TEST_H
+#define POS_WINDOW_TEST_H
+
+#include <QObject>
+
+class POSWindowTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void sellItemUpdatesInventory();
+};
+
+#endif // POS_WINDOW_TEST_H


### PR DESCRIPTION
## Summary
- create `POSWindow` to handle simple point-of-sale sales
- expose new screen from `MainWindow`
- compile new window in application and tests
- add GUI test that performs a sale and checks inventory

## Testing
- `cmake .. && make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687bdc2bad1c83289e10ca62f55f4d7b