### PR TITLE
Add row selection slot to ProductWindow

### DIFF
--- a/src/products/ProductWindow.cpp
+++ b/src/products/ProductWindow.cpp
@@ -23,6 +23,7 @@ ProductWindow::ProductWindow(ProductManager *pm, QWidget *parent)
     m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    connect(m_table, &QTableWidget::itemSelectionChanged, this, &ProductWindow::onRowSelected);
 
     m_nameEdit = new QLineEdit(this);
     m_nameEdit->setObjectName("nameEdit");
@@ -113,5 +114,15 @@ void ProductWindow::onDelete()
         return;
     }
     loadProducts();
+}
+
+void ProductWindow::onRowSelected()
+{
+    int row = m_table->currentRow();
+    if (row < 0)
+        return;
+    m_nameEdit->setText(m_table->item(row, 1)->text());
+    m_priceEdit->setValue(m_table->item(row, 2)->text().toDouble());
+    m_discountEdit->setValue(m_table->item(row, 3)->text().toDouble());
 }
 

--- a/src/products/ProductWindow.h
+++ b/src/products/ProductWindow.h
@@ -22,6 +22,7 @@ private slots:
     void onAdd();
     void onEdit();
     void onDelete();
+    void onRowSelected();
 
 private:
     ProductManager *m_pm;

--- a/tests/product_window_test.cpp
+++ b/tests/product_window_test.cpp
@@ -48,6 +48,12 @@ void ProductWindowTest::addProductUI()
     QCOMPARE(table->rowCount(), 1);
     QCOMPARE(table->item(0,1)->text(), QString("TestItem"));
 
+    // Selecting the row should fill the edit fields
+    table->selectRow(0);
+    QCOMPARE(nameEdit->text(), QString("TestItem"));
+    QCOMPARE(priceEdit->value(), 5.5);
+    QCOMPARE(discountEdit->value(), 0.5);
+
     db.close();
     QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
 }


### PR DESCRIPTION
## Summary
- connect table selection change to new `onRowSelected` slot
- populate edit fields when a row is selected
- verify UI field population in product window tests

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687be54f82c48328934c8240318a0600