### PR TITLE
Add role-based permissions

### DIFF
--- a/src/UserManager.h
+++ b/src/UserManager.h
@@ -15,10 +15,16 @@ public:
     bool updateUserRole(const QString &username, const QString &newRole);
     bool authenticate(const QString &username, const QString &password);
 
+    QString currentUser() const;
+    QString currentRole() const;
+    void logout();
+
     QString lastError() const;
 
 private:
     QString m_lastError;
+    QString m_currentUser;
+    QString m_currentRole;
 };
 
 #endif // USERMANAGER_H

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -3,22 +3,28 @@
 #include "sales/POSWindow.h"
 #include "ProductManager.h"
 #include "SalesManager.h"
+#include "UserManager.h"
 #include <QMenuBar>
 #include <QMenu>
 #include <QAction>
 
-MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent)
+MainWindow::MainWindow(UserManager *userManager, QWidget *parent)
+    : QMainWindow(parent),
+      m_userManager(userManager)
 {
     setWindowTitle(tr("NieS"));
 
     QMenu *prodMenu = menuBar()->addMenu(tr("Products"));
-    QAction *manageAct = prodMenu->addAction(tr("Manage Products"));
-    connect(manageAct, &QAction::triggered, this, &MainWindow::openProducts);
+    m_manageAct = prodMenu->addAction(tr("Manage Products"));
+    m_manageAct->setObjectName("manageAct");
+    connect(m_manageAct, &QAction::triggered, this, &MainWindow::openProducts);
 
     QMenu *salesMenu = menuBar()->addMenu(tr("Sales"));
-    QAction *posAct = salesMenu->addAction(tr("Point of Sale"));
-    connect(posAct, &QAction::triggered, this, &MainWindow::openPOS);
+    m_posAct = salesMenu->addAction(tr("Point of Sale"));
+    m_posAct->setObjectName("posAct");
+    connect(m_posAct, &QAction::triggered, this, &MainWindow::openPOS);
+
+    updatePermissions();
 }
 
 void MainWindow::openProducts()
@@ -37,5 +43,14 @@ void MainWindow::openPOS()
     m_posWindow->show();
     m_posWindow->raise();
     m_posWindow->activateWindow();
+}
+
+void MainWindow::updatePermissions()
+{
+    const QString role = m_userManager ? m_userManager->currentRole() : QString();
+    if (role != "admin")
+        m_manageAct->setEnabled(false);
+    if (role != "seller" && role != "admin")
+        m_posAct->setEnabled(false);
 }
 

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -5,18 +5,24 @@
 
 class ProductWindow;
 class POSWindow;
+class UserManager;
+class QAction;
 
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(UserManager *userManager, QWidget *parent = nullptr);
 
 private slots:
     void openProducts();
     void openPOS();
 
 private:
+    void updatePermissions();
+    UserManager *m_userManager;
+    QAction *m_manageAct = nullptr;
+    QAction *m_posAct = nullptr;
     ProductWindow *m_productWindow = nullptr;
     POSWindow *m_posWindow = nullptr;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-    MainWindow mainWin;
+    MainWindow mainWin(&userManager);
     mainWin.show();
     int ret = app.exec();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     login_test.cpp
     product_window_test.cpp
     pos_window_test.cpp
+    main_window_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
     ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
     ${CMAKE_SOURCE_DIR}/src/ProductManager.cpp

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -7,6 +7,7 @@
 #include "login_test.h"
 #include "product_window_test.h"
 #include "pos_window_test.h"
+#include "main_window_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -673,6 +674,8 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&productWindowTest, argc, argv);
     POSWindowTest posWindowTest;
     status |= QTest::qExec(&posWindowTest, argc, argv);
+    MainWindowTest mainWinTest;
+    status |= QTest::qExec(&mainWinTest, argc, argv);
     return status;
 }
 

--- a/tests/main_window_test.cpp
+++ b/tests/main_window_test.cpp
@@ -1,0 +1,97 @@
+#include <QtTest>
+#include <QApplication>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+#include "login/MainWindow.h"
+#include "UserManager.h"
+#include "main_window_test.h"
+#include <QAction>
+
+static void setupUsersTable()
+{
+    QSqlQuery query;
+    QVERIFY(query.exec("CREATE TABLE users("
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                       "username TEXT UNIQUE,"
+                       "password_hash TEXT,"
+                       "password_salt TEXT,"
+                       "role TEXT,"
+                       "created_at TEXT)"));
+}
+
+class ScopedDb
+{
+public:
+    ScopedDb()
+    {
+        if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+            QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+        db = QSqlDatabase::addDatabase("QSQLITE");
+        db.setDatabaseName(":memory:");
+        QVERIFY(db.open());
+        setupUsersTable();
+    }
+    ~ScopedDb()
+    {
+        db.close();
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    }
+    QSqlDatabase db;
+};
+
+void MainWindowTest::adminFullAccess()
+{
+    ScopedDb scoped;
+    UserManager um;
+    QVERIFY(um.createUser("admin", "pw", "admin"));
+    QVERIFY(um.authenticate("admin", "pw"));
+
+    MainWindow win(&um);
+    win.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&win));
+
+    QAction *manageAct = win.findChild<QAction*>("manageAct");
+    QAction *posAct = win.findChild<QAction*>("posAct");
+    QVERIFY(manageAct && posAct);
+    QVERIFY(manageAct->isEnabled());
+    QVERIFY(posAct->isEnabled());
+}
+
+void MainWindowTest::sellerLimitedAccess()
+{
+    ScopedDb scoped;
+    UserManager um;
+    QVERIFY(um.createUser("sell", "pw", "seller"));
+    QVERIFY(um.authenticate("sell", "pw"));
+
+    MainWindow win(&um);
+    win.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&win));
+
+    QAction *manageAct = win.findChild<QAction*>("manageAct");
+    QAction *posAct = win.findChild<QAction*>("posAct");
+    QVERIFY(manageAct && posAct);
+    QVERIFY(!manageAct->isEnabled());
+    QVERIFY(posAct->isEnabled());
+}
+
+void MainWindowTest::viewerNoAccess()
+{
+    ScopedDb scoped;
+    UserManager um;
+    QVERIFY(um.createUser("view", "pw", "viewer"));
+    QVERIFY(um.authenticate("view", "pw"));
+
+    MainWindow win(&um);
+    win.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&win));
+
+    QAction *manageAct = win.findChild<QAction*>("manageAct");
+    QAction *posAct = win.findChild<QAction*>("posAct");
+    QVERIFY(manageAct && posAct);
+    QVERIFY(!manageAct->isEnabled());
+    QVERIFY(!posAct->isEnabled());
+}
+
+

--- a/tests/main_window_test.h
+++ b/tests/main_window_test.h
@@ -1,0 +1,15 @@
+#ifndef MAIN_WINDOW_TEST_H
+#define MAIN_WINDOW_TEST_H
+
+#include <QObject>
+
+class MainWindowTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void adminFullAccess();
+    void sellerLimitedAccess();
+    void viewerNoAccess();
+};
+
+#endif // MAIN_WINDOW_TEST_H


### PR DESCRIPTION
## Summary
- track current user info in `UserManager`
- show/hide menu actions according to role in `MainWindow`
- pass `UserManager` to `MainWindow`
- add `MainWindowTest` covering permission enforcement

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687be863af6c8328b03d7d8709162f7d