### PR TITLE
Add sales report window

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(NieSApp
     InventoryManager.cpp
     SalesManager.cpp
     sales/POSWindow.cpp
+    sales/SalesReportWindow.cpp
     login/LoginDialog.cpp
     login/MainWindow.cpp
 )

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -1,6 +1,7 @@
 #include "MainWindow.h"
 #include "products/ProductWindow.h"
 #include "sales/POSWindow.h"
+#include "sales/SalesReportWindow.h"
 #include "ProductManager.h"
 #include "SalesManager.h"
 #include "UserManager.h"
@@ -24,6 +25,10 @@ MainWindow::MainWindow(UserManager *userManager, QWidget *parent)
     m_posAct->setObjectName("posAct");
     connect(m_posAct, &QAction::triggered, this, &MainWindow::openPOS);
 
+    m_reportAct = salesMenu->addAction(tr("Sales Report"));
+    m_reportAct->setObjectName("reportAct");
+    connect(m_reportAct, &QAction::triggered, this, &MainWindow::openReport);
+
     updatePermissions();
 }
 
@@ -45,6 +50,15 @@ void MainWindow::openPOS()
     m_posWindow->activateWindow();
 }
 
+void MainWindow::openReport()
+{
+    if (!m_reportWindow)
+        m_reportWindow = new SalesReportWindow(new SalesManager(this), this);
+    m_reportWindow->show();
+    m_reportWindow->raise();
+    m_reportWindow->activateWindow();
+}
+
 void MainWindow::updatePermissions()
 {
     const QString role = m_userManager ? m_userManager->currentRole() : QString();
@@ -52,5 +66,7 @@ void MainWindow::updatePermissions()
         m_manageAct->setEnabled(false);
     if (role != "seller" && role != "admin")
         m_posAct->setEnabled(false);
+    if (role != "admin")
+        m_reportAct->setEnabled(false);
 }
 

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -5,6 +5,7 @@
 
 class ProductWindow;
 class POSWindow;
+class SalesReportWindow;
 class UserManager;
 class QAction;
 
@@ -17,14 +18,17 @@ public:
 private slots:
     void openProducts();
     void openPOS();
+    void openReport();
 
 private:
     void updatePermissions();
     UserManager *m_userManager;
     QAction *m_manageAct = nullptr;
     QAction *m_posAct = nullptr;
+    QAction *m_reportAct = nullptr;
     ProductWindow *m_productWindow = nullptr;
     POSWindow *m_posWindow = nullptr;
+    SalesReportWindow *m_reportWindow = nullptr;
 };
 
 #endif // MAINWINDOW_H

--- a/src/sales/SalesReportWindow.cpp
+++ b/src/sales/SalesReportWindow.cpp
@@ -1,0 +1,46 @@
+#include "SalesReportWindow.h"
+#include "SalesManager.h"
+
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QVBoxLayout>
+
+SalesReportWindow::SalesReportWindow(SalesManager *sm, QWidget *parent)
+    : QWidget(parent),
+      m_sm(sm)
+{
+    setWindowTitle(tr("Sales Report"));
+
+    m_table = new QTableWidget(this);
+    m_table->setObjectName("salesTable");
+    m_table->setColumnCount(5);
+    m_table->setHorizontalHeaderLabels({tr("ID"), tr("Product ID"), tr("Quantity"), tr("Date"), tr("Total")});
+    m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addWidget(m_table);
+
+    loadReport();
+}
+
+void SalesReportWindow::loadReport()
+{
+    m_table->setRowCount(0);
+    if (!m_sm)
+        return;
+    const QList<QVariantMap> sales = m_sm->salesReport();
+    for (int i = 0; i < sales.size(); ++i) {
+        const QVariantMap &s = sales[i];
+        m_table->insertRow(i);
+        m_table->setItem(i, 0, new QTableWidgetItem(s.value("id").toString()));
+        m_table->setItem(i, 1, new QTableWidgetItem(s.value("product_id").toString()));
+        m_table->setItem(i, 2, new QTableWidgetItem(s.value("quantity").toString()));
+        m_table->setItem(i, 3, new QTableWidgetItem(s.value("sale_date").toString()));
+        m_table->setItem(i, 4, new QTableWidgetItem(QString::number(s.value("total").toDouble())));
+    }
+    if (m_table->rowCount() > 0)
+        m_table->selectRow(0);
+}
+

--- a/src/sales/SalesReportWindow.h
+++ b/src/sales/SalesReportWindow.h
@@ -1,0 +1,23 @@
+#ifndef SALESREPORTWINDOW_H
+#define SALESREPORTWINDOW_H
+
+#include <QWidget>
+
+class QTableWidget;
+class SalesManager;
+
+class SalesReportWindow : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit SalesReportWindow(SalesManager *sm, QWidget *parent = nullptr);
+
+public slots:
+    void loadReport();
+
+private:
+    SalesManager *m_sm;
+    QTableWidget *m_table;
+};
+
+#endif // SALESREPORTWINDOW_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,12 +9,14 @@ set(TEST_SOURCES
     login_test.cpp
     product_window_test.cpp
     pos_window_test.cpp
+    sales_report_window_test.cpp
     main_window_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
     ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
     ${CMAKE_SOURCE_DIR}/src/ProductManager.cpp
     ${CMAKE_SOURCE_DIR}/src/products/ProductWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/sales/POSWindow.cpp
+    ${CMAKE_SOURCE_DIR}/src/sales/SalesReportWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/InventoryManager.cpp
     ${CMAKE_SOURCE_DIR}/src/SalesManager.cpp
     ${CMAKE_SOURCE_DIR}/src/login/LoginDialog.cpp

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -8,6 +8,7 @@
 #include "product_window_test.h"
 #include "pos_window_test.h"
 #include "main_window_test.h"
+#include "sales_report_window_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -674,6 +675,8 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&productWindowTest, argc, argv);
     POSWindowTest posWindowTest;
     status |= QTest::qExec(&posWindowTest, argc, argv);
+    SalesReportWindowTest salesReportTest;
+    status |= QTest::qExec(&salesReportTest, argc, argv);
     MainWindowTest mainWinTest;
     status |= QTest::qExec(&mainWinTest, argc, argv);
     return status;

--- a/tests/sales_report_window_test.cpp
+++ b/tests/sales_report_window_test.cpp
@@ -1,0 +1,40 @@
+#include <QtTest>
+#include <QApplication>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+#include <QTableWidget>
+
+#include "sales/SalesReportWindow.h"
+#include "SalesManager.h"
+#include "sales_report_window_test.h"
+
+void SalesReportWindowTest::loadReport()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec("CREATE TABLE sales("\
+                       "id INTEGER PRIMARY KEY AUTOINCREMENT,"\
+                       "product_id INTEGER,"\
+                       "quantity INTEGER,"\
+                       "sale_date TEXT,"\
+                       "total REAL)"));
+    QVERIFY(query.exec("INSERT INTO sales(product_id, quantity, sale_date, total) VALUES(1,1,'2020-01-01',5.0)"));
+
+    SalesManager sm;
+    SalesReportWindow w(&sm);
+    w.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&w));
+
+    auto table = w.findChild<QTableWidget*>("salesTable");
+    QVERIFY(table);
+    QVERIFY(table->rowCount() >= 1);
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+

--- a/tests/sales_report_window_test.h
+++ b/tests/sales_report_window_test.h
@@ -1,0 +1,13 @@
+#ifndef SALES_REPORT_WINDOW_TEST_H
+#define SALES_REPORT_WINDOW_TEST_H
+
+#include <QObject>
+
+class SalesReportWindowTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void loadReport();
+};
+
+#endif // SALES_REPORT_WINDOW_TEST_H


### PR DESCRIPTION
## Summary
- implement `SalesReportWindow` to display table of sales
- wire sales report window into the main menu
- support new class in build files
- add simple UI test for the sales report window

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687bec37ef4c8328ba291bff763d01df