### PR TITLE
Add database seed script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,9 @@ add_subdirectory(examples/connectdb)
 
 enable_testing()
 add_subdirectory(tests)
+
+if(DEFINED SEED_DB_NAME AND DEFINED SEED_DB_USER)
+    add_custom_target(seed_db
+        COMMAND sh -c "mysql -u ${SEED_DB_USER} ${SEED_DB_NAME} < ${CMAKE_SOURCE_DIR}/database/seed.sql"
+        COMMENT "Load demo data into the database")
+endif()

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ subsequent runs skip migrations that were already executed:
 ./database/migrate.sh <your_database> <your_user>
 ```
 
+To populate your fresh database with a small demo dataset, run:
+
+```sh
+mysql -u <your_user> <your_database> < database/seed.sql
+```
+
+This creates an administrator account (`admin`/`adminpass`) and a couple of
+example products so you can explore the application right away.
+
 ## Troubleshooting
 
 If the application fails to connect to MySQL, check the following:

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -1,0 +1,19 @@
+-- Sample data for initial setup
+
+-- Admin user with password "adminpass"
+INSERT INTO users(username, password_hash, password_salt, role) VALUES
+  ('admin', '0ba52449484358aec21151459f761b9122028c2a77fbbe41d86ecd59d2b3936e', 'eea52bddd5194422a84159ea8e401f7f', 'admin');
+
+-- Example products
+INSERT INTO products(name, price, discount) VALUES
+  ('Coffee', 5.00, 0),
+  ('Tea', 3.50, 0);
+
+-- Inventory entries
+INSERT INTO inventory(product_id, quantity) VALUES
+  (1, 50),
+  (2, 30);
+
+-- Sample sale
+INSERT INTO sales(product_id, quantity, total) VALUES
+  (1, 2, 10.00);


### PR DESCRIPTION
## Summary
- add `database/seed.sql` with an admin account and sample products
- document demo data load procedure in README
- expose an optional `seed_db` CMake target for convenience

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687bf897c54883288fe64dbdeeae0ec6