### PR TITLE
Remove unused postgres deps from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ qtbase5-dev qttools5-dev qttools5-dev-tools libqt5sql5 libqt5sql5-psql libpq-dev postgresql
+          sudo apt-get install -y cmake g++ qtbase5-dev qttools5-dev qttools5-dev-tools libqt5sql5 libqt5sql5-psql
       - name: Configure
         run: cmake -B build -S .
       - name: Build


### PR DESCRIPTION
## Summary
- drop `libpq-dev` and `postgresql` from CI setup because Postgres tests are commented out

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687bfd9bd370832892a55fc03614a525