### PR TITLE
Add automatic offline synchronization

### DIFF
--- a/NieSApp.pro
+++ b/NieSApp.pro
@@ -1,4 +1,4 @@
-QT += widgets sql
+QT += widgets sql network
 CONFIG += c++11 console
 TEMPLATE = app
 TARGET = NieSApp
@@ -12,6 +12,7 @@ SOURCES += \
     src/SalesManager.cpp \
     src/login/LoginDialog.cpp \
     src/login/MainWindow.cpp
+    src/NetworkMonitor.cpp
 
 HEADERS += \
     src/DatabaseManager.h \
@@ -21,6 +22,7 @@ HEADERS += \
     src/SalesManager.h \
     src/login/LoginDialog.h \
     src/login/MainWindow.h
+    src/NetworkMonitor.h
 
 # Include config file for convenience
 OTHER_FILES += config.ini

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ SQLite file when the application cannot connect to MySQL. The file location is
 controlled by `offline_path` or the `NIES_DB_OFFLINE_PATH` environment
 variable. Call `DatabaseManager::synchronize()` once connectivity is restored to
 push pending records to the MySQL server.
+The application now includes a small `NetworkMonitor` helper that listens for
+changes in network connectivity. When offline mode is enabled and the network
+becomes available again, `DatabaseManager` automatically triggers
+`synchronize()` so pending rows are uploaded without manual intervention.
 
 Example using environment variables:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt5 COMPONENTS Widgets Sql LinguistTools REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Sql Network LinguistTools REQUIRED)
 
 add_executable(NieSApp
     main.cpp
@@ -24,9 +24,10 @@ add_executable(NieSApp
     dashboard/DashboardWindow.cpp
     login/LoginDialog.cpp
     login/MainWindow.cpp
+    NetworkMonitor.cpp
 )
 
-target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql)
+target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql Qt5::Network)
 target_include_directories(NieSApp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(TS_FILES

--- a/src/NetworkMonitor.cpp
+++ b/src/NetworkMonitor.cpp
@@ -1,0 +1,17 @@
+#include "NetworkMonitor.h"
+
+NetworkMonitor::NetworkMonitor(QObject *parent)
+    : QObject(parent),
+      m_isOnline(m_manager.isOnline())
+{
+    connect(&m_manager, &QNetworkConfigurationManager::onlineStateChanged,
+            this, &NetworkMonitor::handleOnlineStateChanged);
+}
+
+void NetworkMonitor::handleOnlineStateChanged(bool isOnline)
+{
+    if (m_isOnline == isOnline)
+        return;
+    m_isOnline = isOnline;
+    emit connectivityChanged(m_isOnline);
+}

--- a/src/NetworkMonitor.h
+++ b/src/NetworkMonitor.h
@@ -1,0 +1,25 @@
+#ifndef NETWORKMONITOR_H
+#define NETWORKMONITOR_H
+
+#include <QObject>
+#include <QNetworkConfigurationManager>
+
+class NetworkMonitor : public QObject
+{
+    Q_OBJECT
+public:
+    explicit NetworkMonitor(QObject *parent = nullptr);
+    bool isOnline() const { return m_isOnline; }
+
+signals:
+    void connectivityChanged(bool online);
+
+private slots:
+    void handleOnlineStateChanged(bool isOnline);
+
+private:
+    QNetworkConfigurationManager m_manager;
+    bool m_isOnline;
+};
+
+#endif // NETWORKMONITOR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "UserManager.h"
 #include "login/LoginDialog.h"
 #include "login/MainWindow.h"
+#include "NetworkMonitor.h"
 
 int main(int argc, char *argv[])
 {
@@ -23,6 +24,13 @@ int main(int argc, char *argv[])
         QMessageBox::critical(nullptr, "Database Error", db.lastError());
         return -1;
     }
+
+    NetworkMonitor monitor;
+    QObject::connect(&monitor, &NetworkMonitor::connectivityChanged,
+                     [&db](bool online) {
+        if (online && db.isOffline())
+            db.synchronize();
+    });
 
     UserManager userManager;
     LoginDialog login(&userManager);


### PR DESCRIPTION
## Summary
- add `NetworkMonitor` helper class to detect connectivity changes
- integrate network monitor in `main.cpp` to synchronize when coming online
- link Qt Network module in builds
- document automatic syncing in README

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c056ecf9483288b235313053d7303