### PR TITLE
Clarify payment processing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Le projet en est à ses débuts. Les composants suivants sont disponibles :
 * Enregistrement des ventes et mise à jour automatique du stock.
 * Gestion des retours et remboursements.
 * Impression de factures depuis le POS.
-* Paiements numériques (cartes, mobile money, QR codes).
+* Paiements numériques (cartes, mobile money, QR codes). Les transactions sont actuellement simulées.
 * Rapports financiers détaillés et calcul des bénéfices.
 * Tableaux de bord avec indicateurs clés (ventes, niveaux de stock).
 * Prédiction de stock et alertes de seuil critique.
@@ -115,6 +115,13 @@ The application loads translations from the `translations` directory next to the
 executable. Use `lupdate` to update the `.ts` files and `cmake` will compile
 them to `.qm` at build time. At runtime, `NieSApp` selects the translation that
 matches your system locale.
+
+### Payment Processing (Simulated)
+
+`PaymentProcessor` currently performs no real transactions. Calls to process
+card, mobile money or QR code payments simply log the amount and report success
+without contacting any external service. Integrate a payment gateway in this
+class to accept actual payments.
 
 ## Running Tests
 

--- a/src/payments/PaymentProcessor.cpp
+++ b/src/payments/PaymentProcessor.cpp
@@ -1,4 +1,5 @@
 #include "payments/PaymentProcessor.h"
+#include <QDebug>
 
 PaymentProcessor::PaymentProcessor(QObject *parent)
     : QObject(parent)
@@ -7,20 +8,35 @@ PaymentProcessor::PaymentProcessor(QObject *parent)
 
 bool PaymentProcessor::processCard(double amount)
 {
-    Q_UNUSED(amount);
-    // Here an actual card payment API would be called.
+    if (amount <= 0) {
+        m_lastError = tr("Invalid amount");
+        return false;
+    }
+
+    // Simulation of a real card payment. Replace with actual gateway call.
+    qDebug() << "Simulated card payment:" << amount;
     return true;
 }
 
 bool PaymentProcessor::processMobileMoney(double amount)
 {
-    Q_UNUSED(amount);
+    if (amount <= 0) {
+        m_lastError = tr("Invalid amount");
+        return false;
+    }
+
+    qDebug() << "Simulated mobile money payment:" << amount;
     return true;
 }
 
 bool PaymentProcessor::processQrCode(double amount)
 {
-    Q_UNUSED(amount);
+    if (amount <= 0) {
+        m_lastError = tr("Invalid amount");
+        return false;
+    }
+
+    qDebug() << "Simulated QR code payment:" << amount;
     return true;
 }
 

--- a/src/payments/PaymentProcessor.h
+++ b/src/payments/PaymentProcessor.h
@@ -4,6 +4,9 @@
 #include <QObject>
 #include <QString>
 
+// Basic payment handler used by the POS window. The current implementation
+// only simulates successful transactions. Integrate with a real payment
+// gateway to accept actual payments.
 class PaymentProcessor : public QObject
 {
     Q_OBJECT


### PR DESCRIPTION
## Summary
- mark `PaymentProcessor` as simulated
- log transactions and validate amount
- document payment simulation in README

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c0de8cf48832899bf940b063d230e