### PR TITLE
Implement dashboard KPIs

### DIFF
--- a/src/dashboard/DashboardWindow.cpp
+++ b/src/dashboard/DashboardWindow.cpp
@@ -3,19 +3,57 @@
 #include "InventoryManager.h"
 #include <QVBoxLayout>
 #include <QLabel>
+#include <QVariantMap>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlDatabase>
 
 DashboardWindow::DashboardWindow(SalesManager *sm, InventoryManager *im, QWidget *parent)
     : QWidget(parent), m_sm(sm), m_im(im)
 {
     setWindowTitle(tr("Dashboard"));
     auto *layout = new QVBoxLayout(this);
-    layout->addWidget(new QLabel(tr("Sales and inventory KPIs will be shown here."), this));
+
+    m_revenueLabel = new QLabel(this);
+    m_revenueLabel->setObjectName("revenueLabel");
+    layout->addWidget(m_revenueLabel);
+
+    m_unitsLabel = new QLabel(this);
+    m_unitsLabel->setObjectName("unitsLabel");
+    layout->addWidget(m_unitsLabel);
+
+    m_stockLabel = new QLabel(this);
+    m_stockLabel->setObjectName("stockLabel");
+    layout->addWidget(m_stockLabel);
+
+    refresh();
 }
 
 void DashboardWindow::refresh()
 {
-    Q_UNUSED(m_sm);
-    Q_UNUSED(m_im);
-    // Would fetch data and update widgets
+    double revenue = 0.0;
+    int units = 0;
+    if (m_sm) {
+        const QVariantMap report = m_sm->financialReport();
+        revenue = report.value("revenue").toDouble();
+        units = report.value("units").toInt();
+    }
+
+    int stock = 0;
+    if (m_im) {
+        QSqlDatabase db = QSqlDatabase::database();
+        if (db.isOpen()) {
+            QSqlQuery q(db);
+            q.prepare("SELECT SUM(quantity) FROM inventory");
+            if (q.exec() && q.next())
+                stock = q.value(0).toInt();
+        }
+    }
+
+    if (m_revenueLabel)
+        m_revenueLabel->setText(tr("Total revenue: %1").arg(QString::number(revenue)));
+    if (m_unitsLabel)
+        m_unitsLabel->setText(tr("Units sold: %1").arg(units));
+    if (m_stockLabel)
+        m_stockLabel->setText(tr("Stock on hand: %1").arg(stock));
 }
 

--- a/src/dashboard/DashboardWindow.h
+++ b/src/dashboard/DashboardWindow.h
@@ -6,6 +6,8 @@
 class SalesManager;
 class InventoryManager;
 
+class QLabel;
+
 class DashboardWindow : public QWidget
 {
     Q_OBJECT
@@ -18,6 +20,9 @@ public slots:
 private:
     SalesManager *m_sm;
     InventoryManager *m_im;
+    QLabel *m_revenueLabel = nullptr;
+    QLabel *m_unitsLabel = nullptr;
+    QLabel *m_stockLabel = nullptr;
 };
 
 #endif // DASHBOARDWINDOW_H

--- a/tests/dashboard_window_test.cpp
+++ b/tests/dashboard_window_test.cpp
@@ -5,10 +5,33 @@
 #include "dashboard/DashboardWindow.h"
 #include "SalesManager.h"
 #include "InventoryManager.h"
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
 #include "dashboard_window_test.h"
 
 void DashboardWindowTest::initUi()
 {
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery q;
+    QVERIFY(q.exec("CREATE TABLE sales("\
+                   "id INTEGER PRIMARY KEY AUTOINCREMENT,"\
+                   "product_id INTEGER,"\
+                   "quantity INTEGER,"\
+                   "sale_date TEXT,"\
+                   "total REAL)"));
+    QVERIFY(q.exec("CREATE TABLE inventory("\
+                   "id INTEGER PRIMARY KEY AUTOINCREMENT,"\
+                   "product_id INTEGER,"\
+                   "quantity INTEGER)"));
+    QVERIFY(q.exec("INSERT INTO sales(product_id, quantity, sale_date, total) "
+                   "VALUES(1,2,'2020-01-01',10.5)"));
+    QVERIFY(q.exec("INSERT INTO inventory(product_id, quantity) VALUES(1,5)"));
+
     SalesManager sm;
     InventoryManager im;
     DashboardWindow w(&sm, &im);
@@ -16,7 +39,16 @@ void DashboardWindowTest::initUi()
     w.show();
     QVERIFY(QTest::qWaitForWindowExposed(&w));
     w.refresh();
-    auto label = w.findChild<QLabel*>();
-    QVERIFY(label);
+
+    auto revenue = w.findChild<QLabel*>("revenueLabel");
+    auto units = w.findChild<QLabel*>("unitsLabel");
+    auto stock = w.findChild<QLabel*>("stockLabel");
+    QVERIFY(revenue && units && stock);
+    QCOMPARE(revenue->text(), QString("Total revenue: 10.5"));
+    QCOMPARE(units->text(), QString("Units sold: 2"));
+    QCOMPARE(stock->text(), QString("Stock on hand: 5"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
 }
 


### PR DESCRIPTION
## Summary
- show revenue, units sold, and current stock in DashboardWindow
- implement refresh() to query managers and update labels
- test dashboard KPIs

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687c2b75ad788328b3f06e31461f178d