### PR TITLE
Add low-stock prediction panel

### DIFF
--- a/src/InventoryManager.cpp
+++ b/src/InventoryManager.cpp
@@ -80,6 +80,8 @@ bool InventoryManager::updateStock(int productId, int delta)
         m_lastError = modify.lastError().text();
         return false;
     }
+
+    emit stockChanged(productId, newQty);
     return true;
 }
 

--- a/src/InventoryManager.h
+++ b/src/InventoryManager.h
@@ -19,6 +19,9 @@ public:
 
     QString lastError() const;
 
+signals:
+    void stockChanged(int productId, int newQuantity);
+
 private:
     bool updateStock(int productId, int delta);
     QString m_lastError;

--- a/src/SalesManager.cpp
+++ b/src/SalesManager.cpp
@@ -59,6 +59,7 @@ bool SalesManager::recordSale(int productId, int quantity)
         return false;
     }
 
+    emit saleRecorded(productId, quantity);
     return true;
 }
 

--- a/src/SalesManager.h
+++ b/src/SalesManager.h
@@ -20,6 +20,9 @@ public:
 
     QString lastError() const;
 
+signals:
+    void saleRecorded(int productId, int quantity);
+
 private:
     QString m_lastError;
     InventoryManager m_inventory;

--- a/src/dashboard/DashboardWindow.h
+++ b/src/dashboard/DashboardWindow.h
@@ -2,6 +2,10 @@
 #define DASHBOARDWINDOW_H
 
 #include <QWidget>
+#include <QTimer>
+
+class QListWidget;
+#include "stock/StockPrediction.h"
 
 class SalesManager;
 class InventoryManager;
@@ -16,10 +20,14 @@ public:
 
 public slots:
     void refresh();
+    void refreshPredictions();
 
 private:
     SalesManager *m_sm;
     InventoryManager *m_im;
+    StockPrediction m_prediction;
+    QTimer m_timer;
+    QListWidget *m_predictionList = nullptr;
     QLabel *m_revenueLabel = nullptr;
     QLabel *m_unitsLabel = nullptr;
     QLabel *m_stockLabel = nullptr;


### PR DESCRIPTION
## Summary
- extend `DashboardWindow` with a list showing predicted demand and low stock
- emit `saleRecorded` in `SalesManager`
- emit `stockChanged` in `InventoryManager`
- hook the new signals to refresh predictions automatically

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c2deb95a08328b9c93d4342b14ab2