### PR TITLE
Add UserWindow management UI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(NieSApp
     dashboard/DashboardWindow.cpp
     login/LoginDialog.cpp
     login/MainWindow.cpp
+    login/UserWindow.cpp
     NetworkMonitor.cpp
     UserSession.cpp
 )

--- a/src/UserManager.cpp
+++ b/src/UserManager.cpp
@@ -2,6 +2,7 @@
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
 #include <QVariant>
+#include <QVariantMap>
 #include <QCryptographicHash>
 #include <QUuid>
 
@@ -81,6 +82,23 @@ bool UserManager::authenticate(const QString &username, const QString &password)
     m_currentUser = username;
     m_currentRole = role;
     return true;
+}
+
+QList<QVariantMap> UserManager::listUsers()
+{
+    QList<QVariantMap> users;
+    QSqlQuery query("SELECT username, role FROM users ORDER BY id");
+    if (!query.exec()) {
+        m_lastError = query.lastError().text();
+        return users;
+    }
+    while (query.next()) {
+        QVariantMap u;
+        u.insert("username", query.value(0));
+        u.insert("role", query.value(1));
+        users.append(u);
+    }
+    return users;
 }
 
 QString UserManager::lastError() const

--- a/src/UserManager.h
+++ b/src/UserManager.h
@@ -3,6 +3,8 @@
 
 #include <QObject>
 #include <QString>
+#include <QList>
+#include <QVariantMap>
 
 class UserManager : public QObject
 {
@@ -14,6 +16,7 @@ public:
     bool deleteUser(const QString &username);
     bool updateUserRole(const QString &username, const QString &newRole);
     bool authenticate(const QString &username, const QString &password);
+    QList<QVariantMap> listUsers();
 
     QString currentUser() const;
     QString currentRole() const;

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -2,6 +2,8 @@
 #include "products/ProductWindow.h"
 #include "sales/POSWindow.h"
 #include "sales/SalesReportWindow.h"
+#include "login/UserWindow.h"
+#include "UserManager.h"
 #include "ProductManager.h"
 #include "SalesManager.h"
 #include "UserSession.h"
@@ -28,6 +30,11 @@ MainWindow::MainWindow(UserSession *session, QWidget *parent)
     m_reportAct = salesMenu->addAction(tr("Sales Report"));
     m_reportAct->setObjectName("reportAct");
     connect(m_reportAct, &QAction::triggered, this, &MainWindow::openReport);
+
+    QMenu *userMenu = menuBar()->addMenu(tr("Users"));
+    m_usersAct = userMenu->addAction(tr("Manage Users"));
+    m_usersAct->setObjectName("usersAct");
+    connect(m_usersAct, &QAction::triggered, this, &MainWindow::openUsers);
 
     updatePermissions();
 }
@@ -59,6 +66,15 @@ void MainWindow::openReport()
     m_reportWindow->activateWindow();
 }
 
+void MainWindow::openUsers()
+{
+    if (!m_userWindow)
+        m_userWindow = new UserWindow(new UserManager(this), this);
+    m_userWindow->show();
+    m_userWindow->raise();
+    m_userWindow->activateWindow();
+}
+
 void MainWindow::updatePermissions()
 {
     const QString role = m_session ? m_session->role() : QString();
@@ -68,5 +84,7 @@ void MainWindow::updatePermissions()
         m_posAct->setEnabled(false);
     if (role != "admin")
         m_reportAct->setEnabled(false);
+    if (role != "admin")
+        m_usersAct->setEnabled(false);
 }
 

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -6,6 +6,7 @@
 class ProductWindow;
 class POSWindow;
 class SalesReportWindow;
+class UserWindow;
 class UserSession;
 class QAction;
 
@@ -19,6 +20,7 @@ private slots:
     void openProducts();
     void openPOS();
     void openReport();
+    void openUsers();
 
 private:
     void updatePermissions();
@@ -26,9 +28,11 @@ private:
     QAction *m_manageAct = nullptr;
     QAction *m_posAct = nullptr;
     QAction *m_reportAct = nullptr;
+    QAction *m_usersAct = nullptr;
     ProductWindow *m_productWindow = nullptr;
     POSWindow *m_posWindow = nullptr;
     SalesReportWindow *m_reportWindow = nullptr;
+    UserWindow *m_userWindow = nullptr;
 };
 
 #endif // MAINWINDOW_H

--- a/src/login/UserWindow.cpp
+++ b/src/login/UserWindow.cpp
@@ -1,0 +1,125 @@
+#include "login/UserWindow.h"
+#include "UserManager.h"
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QMessageBox>
+
+UserWindow::UserWindow(UserManager *um, QWidget *parent)
+    : QWidget(parent), m_um(um)
+{
+    setWindowTitle(tr("Users"));
+
+    m_table = new QTableWidget(this);
+    m_table->setObjectName("userTable");
+    m_table->setColumnCount(2);
+    m_table->setHorizontalHeaderLabels({tr("Username"), tr("Role")});
+    m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    connect(m_table, &QTableWidget::itemSelectionChanged, this, &UserWindow::onRowSelected);
+
+    m_userEdit = new QLineEdit(this);
+    m_userEdit->setObjectName("userEdit");
+    m_passEdit = new QLineEdit(this);
+    m_passEdit->setObjectName("passEdit");
+    m_passEdit->setEchoMode(QLineEdit::Password);
+    m_roleEdit = new QLineEdit(this);
+    m_roleEdit->setObjectName("roleEdit");
+
+    m_addBtn = new QPushButton(tr("Add"), this);
+    m_editBtn = new QPushButton(tr("Change Role"), this);
+    m_deleteBtn = new QPushButton(tr("Delete"), this);
+
+    connect(m_addBtn, &QPushButton::clicked, this, &UserWindow::onAdd);
+    connect(m_editBtn, &QPushButton::clicked, this, &UserWindow::onEdit);
+    connect(m_deleteBtn, &QPushButton::clicked, this, &UserWindow::onDelete);
+
+    QFormLayout *form = new QFormLayout;
+    form->addRow(tr("Username"), m_userEdit);
+    form->addRow(tr("Password"), m_passEdit);
+    form->addRow(tr("Role"), m_roleEdit);
+
+    QHBoxLayout *buttons = new QHBoxLayout;
+    buttons->addWidget(m_addBtn);
+    buttons->addWidget(m_editBtn);
+    buttons->addWidget(m_deleteBtn);
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addWidget(m_table);
+    layout->addLayout(form);
+    layout->addLayout(buttons);
+
+    loadUsers();
+}
+
+void UserWindow::loadUsers()
+{
+    m_table->setRowCount(0);
+    if (!m_um)
+        return;
+    const QList<QVariantMap> users = m_um->listUsers();
+    for (int i = 0; i < users.size(); ++i) {
+        m_table->insertRow(i);
+        const QVariantMap &u = users[i];
+        m_table->setItem(i, 0, new QTableWidgetItem(u.value("username").toString()));
+        m_table->setItem(i, 1, new QTableWidgetItem(u.value("role").toString()));
+    }
+    if (m_table->rowCount() > 0)
+        m_table->selectRow(0);
+}
+
+void UserWindow::onAdd()
+{
+    if (!m_um || m_userEdit->text().isEmpty() || m_passEdit->text().isEmpty())
+        return;
+    if (!m_um->createUser(m_userEdit->text(), m_passEdit->text(), m_roleEdit->text())) {
+        QMessageBox::warning(this, tr("Error"), m_um->lastError());
+        return;
+    }
+    m_userEdit->clear();
+    m_passEdit->clear();
+    m_roleEdit->clear();
+    loadUsers();
+}
+
+void UserWindow::onEdit()
+{
+    int row = m_table->currentRow();
+    if (row < 0 || !m_um)
+        return;
+    QString username = m_table->item(row, 0)->text();
+    if (!m_um->updateUserRole(username, m_roleEdit->text())) {
+        QMessageBox::warning(this, tr("Error"), m_um->lastError());
+        return;
+    }
+    loadUsers();
+}
+
+void UserWindow::onDelete()
+{
+    int row = m_table->currentRow();
+    if (row < 0 || !m_um)
+        return;
+    QString username = m_table->item(row, 0)->text();
+    if (!m_um->deleteUser(username)) {
+        QMessageBox::warning(this, tr("Error"), m_um->lastError());
+        return;
+    }
+    loadUsers();
+}
+
+void UserWindow::onRowSelected()
+{
+    int row = m_table->currentRow();
+    if (row < 0)
+        return;
+    m_userEdit->setText(m_table->item(row, 0)->text());
+    m_roleEdit->setText(m_table->item(row, 1)->text());
+    m_passEdit->clear();
+}
+

--- a/src/login/UserWindow.h
+++ b/src/login/UserWindow.h
@@ -1,0 +1,39 @@
+#ifndef USERWINDOW_H
+#define USERWINDOW_H
+
+#include <QWidget>
+#include <QList>
+#include <QVariantMap>
+
+class QTableWidget;
+class QLineEdit;
+class QPushButton;
+class UserManager;
+
+class UserWindow : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit UserWindow(UserManager *um, QWidget *parent = nullptr);
+
+public slots:
+    void loadUsers();
+
+private slots:
+    void onAdd();
+    void onEdit();
+    void onDelete();
+    void onRowSelected();
+
+private:
+    UserManager *m_um;
+    QTableWidget *m_table;
+    QLineEdit *m_userEdit;
+    QLineEdit *m_passEdit;
+    QLineEdit *m_roleEdit;
+    QPushButton *m_addBtn;
+    QPushButton *m_editBtn;
+    QPushButton *m_deleteBtn;
+};
+
+#endif // USERWINDOW_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(Qt5 COMPONENTS Test Sql Widgets Network REQUIRED)
 set(TEST_SOURCES
     database_test.cpp
     login_test.cpp
+    user_window_test.cpp
     product_window_test.cpp
     pos_window_test.cpp
     sales_report_window_test.cpp
@@ -31,6 +32,7 @@ set(TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/dashboard/DashboardWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/login/LoginDialog.cpp
     ${CMAKE_SOURCE_DIR}/src/login/MainWindow.cpp
+    ${CMAKE_SOURCE_DIR}/src/login/UserWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/UserSession.cpp
 )
 

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -14,6 +14,7 @@
 #include "payment_processor_test.h"
 #include "dashboard_window_test.h"
 #include "stock_prediction_test.h"
+#include "user_window_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -745,6 +746,8 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&paymentTest, argc, argv);
     DashboardWindowTest dashboardTest;
     status |= QTest::qExec(&dashboardTest, argc, argv);
+    UserWindowTest userWinTest;
+    status |= QTest::qExec(&userWinTest, argc, argv);
     StockPredictionTest stockTest;
     status |= QTest::qExec(&stockTest, argc, argv);
     return status;

--- a/tests/user_window_test.cpp
+++ b/tests/user_window_test.cpp
@@ -1,0 +1,96 @@
+#include <QtTest>
+#include <QApplication>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+#include <QLineEdit>
+#include <QTableWidget>
+
+#include "login/UserWindow.h"
+#include "UserManager.h"
+#include "user_window_test.h"
+
+void UserWindowTest::createUserUI()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec(
+               "CREATE TABLE users("
+               "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+               "username TEXT UNIQUE,"
+               "password_hash TEXT,"
+               "password_salt TEXT,"
+               "role TEXT,"
+               "created_at TEXT)"));
+
+    UserManager um;
+    UserWindow w(&um);
+    w.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&w));
+
+    auto userEdit = w.findChild<QLineEdit*>("userEdit");
+    auto passEdit = w.findChild<QLineEdit*>("passEdit");
+    auto roleEdit = w.findChild<QLineEdit*>("roleEdit");
+    QVERIFY(userEdit && passEdit && roleEdit);
+
+    userEdit->setText("alice");
+    passEdit->setText("pw");
+    roleEdit->setText("seller");
+
+    QVERIFY(QMetaObject::invokeMethod(&w, "onAdd", Qt::DirectConnection));
+
+    auto table = w.findChild<QTableWidget*>("userTable");
+    QVERIFY(table);
+    QCOMPARE(table->rowCount(), 1);
+    QCOMPARE(table->item(0,0)->text(), QString("alice"));
+    QCOMPARE(table->item(0,1)->text(), QString("seller"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+
+void UserWindowTest::changeRoleUI()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    QSqlQuery query;
+    QVERIFY(query.exec(
+               "CREATE TABLE users("
+               "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+               "username TEXT UNIQUE,"
+               "password_hash TEXT,"
+               "password_salt TEXT,"
+               "role TEXT,"
+               "created_at TEXT)"));
+    UserManager um;
+    QVERIFY(um.createUser("bob", "pw", "seller"));
+
+    UserWindow w(&um);
+    w.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&w));
+
+    auto table = w.findChild<QTableWidget*>("userTable");
+    QVERIFY(table);
+    QVERIFY(table->rowCount() == 1);
+    table->selectRow(0);
+
+    auto roleEdit = w.findChild<QLineEdit*>("roleEdit");
+    QVERIFY(roleEdit);
+    roleEdit->setText("admin");
+
+    QVERIFY(QMetaObject::invokeMethod(&w, "onEdit", Qt::DirectConnection));
+
+    QCOMPARE(table->item(0,1)->text(), QString("admin"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+

--- a/tests/user_window_test.h
+++ b/tests/user_window_test.h
@@ -1,0 +1,14 @@
+#ifndef USER_WINDOW_TEST_H
+#define USER_WINDOW_TEST_H
+
+#include <QObject>
+
+class UserWindowTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void createUserUI();
+    void changeRoleUI();
+};
+
+#endif // USER_WINDOW_TEST_H


### PR DESCRIPTION
## Summary
- implement UserWindow to CRUD users using UserManager
- show Manage Users menu entry for admins in MainWindow
- expose listUsers in UserManager
- test user management UI for creation and role editing

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687c32fb14208328bb8f170fab591580