### PR TITLE
Add language config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ connection settings via environment variables:
 - `NIES_DB_PASSWORD` – database password
 - `NIES_DB_DRIVER` – Qt SQL driver (e.g. `QMYSQL`, `QSQLITE`)
 - `NIES_DB_OFFLINE_PATH` – path to the offline SQLite file
+- `NIES_LANG` – override the UI language (e.g. `fr_FR`)
 
 ### Offline Mode
 
@@ -117,7 +118,8 @@ This runs the application entirely with the local SQLite file `mydata.db`.
 The application loads translations from the `translations` directory next to the
 executable. Use `lupdate` to update the `.ts` files and `cmake` will compile
 them to `.qm` at build time. At runtime, `NieSApp` selects the translation that
-matches your system locale.
+matches your system locale by default. Set `language` in `config.ini` (section
+`[app]`) or the `NIES_LANG` environment variable to override it.
 
 To add a new language, duplicate `translations/NieS_fr.ts` with the desired
 locale name such as `NieS_es.ts`. Translate the strings inside the

--- a/config.example.ini
+++ b/config.example.ini
@@ -17,3 +17,8 @@ offline_path=nies_local.db
 endpoint=https://api.example.com/pay
 # Secret API key used for authentication
 api_key=your_key_here
+
+[app]
+# Preferred UI language (e.g. fr_FR). Overrides system locale and
+# can also be set with the NIES_LANG environment variable.
+language=

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 #include <QMessageBox>
 #include <QLocale>
 #include <QTranslator>
+#include <QSettings>
+#include <QProcessEnvironment>
 #include "DatabaseManager.h"
 #include "UserManager.h"
 #include "UserSession.h"
@@ -14,7 +16,21 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
 
     QTranslator translator;
-    const QString locale = QLocale::system().name();
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+    QString locale;
+    if (env.contains("NIES_LANG"))
+        locale = env.value("NIES_LANG");
+    if (locale.isEmpty()) {
+        QString cfg = env.contains("NIES_CONFIG_PATH")
+                ? env.value("NIES_CONFIG_PATH")
+                : QCoreApplication::applicationDirPath() + "/config.ini";
+        QSettings settings(cfg, QSettings::IniFormat);
+        locale = settings.value("app/language").toString();
+    }
+    if (locale.isEmpty())
+        locale = QLocale::system().name();
+
     const QString trPath = QCoreApplication::applicationDirPath() + "/translations";
     if (translator.load("NieS_" + locale, trPath)) {
         app.installTranslator(&translator);


### PR DESCRIPTION
## Summary
- add an `[app]` section with a `language` option
- respect the new option or `NIES_LANG` env var when loading translations
- document language configuration in README

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c3741bf00832893a6504aa47c49ce