### PR TITLE
Add --config option with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ make
 Before running, duplicate `config.example.ini` as `config.ini` and configure
 your database parameters. `DatabaseManager` looks for this file next to the
 executable by default. You may specify a custom location with the
-`NIES_CONFIG_PATH` environment variable or by passing a path
-to the `DatabaseManager` constructor. You can also override individual
+`--config` option, with the `NIES_CONFIG_PATH` environment variable,
+or by passing a path to the `DatabaseManager` constructor. You can also override individual
 connection settings via environment variables:
 
 - `NIES_DB_HOST` – database host
@@ -200,7 +200,8 @@ example products so you can explore the application right away.
 If the application fails to connect to MySQL, check the following:
 
 1. **Configuration file available** – copy `config.example.ini` to `config.ini`
-   next to the executable (or the path specified via `NIES_CONFIG_PATH`) and
+   next to the executable (or the path specified via `--config` or
+   `NIES_CONFIG_PATH`) and
    fill in actual values for `name`, `user` and `password`.
 2. **Environment overrides** – The variables `NIES_DB_HOST`, `NIES_DB_PORT`,
    `NIES_DB_NAME`, `NIES_DB_USER` and `NIES_DB_PASSWORD` can override settings at

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <QTranslator>
 #include <QSettings>
 #include <QProcessEnvironment>
+#include <QCommandLineParser>
 #include "DatabaseManager.h"
 #include "UserManager.h"
 #include "UserSession.h"
@@ -17,6 +18,19 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+
+    QCommandLineParser parser;
+    parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+    QCommandLineOption configOption(QStringList{"config"},
+                                   "Path to configuration file",
+                                   "file");
+    parser.addOption(configOption);
+    parser.addHelpOption();
+    parser.process(app);
+
+    QString cmdConfigPath;
+    if (parser.isSet(configOption))
+        cmdConfigPath = parser.value(configOption);
 
     QTranslator translator;
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
@@ -50,7 +64,7 @@ int main(int argc, char *argv[])
         app.installTranslator(&translator);
     }
 
-    DatabaseManager db;
+    DatabaseManager db(cmdConfigPath);
     if (!db.open()) {
         QMessageBox::critical(nullptr, "Database Error", db.lastError());
         return -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
     payment_processor_test.cpp
     dashboard_window_test.cpp
     stock_prediction_test.cpp
+    config_option_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
     ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
     ${CMAKE_SOURCE_DIR}/src/ProductManager.cpp

--- a/tests/config_option_test.cpp
+++ b/tests/config_option_test.cpp
@@ -1,0 +1,44 @@
+#include <QtTest>
+#include <QCommandLineParser>
+#include <QTemporaryDir>
+#include <QSettings>
+#include "DatabaseManager.h"
+#include "config_option_test.h"
+
+void ConfigOptionTest::cliOverridesEnv()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    const QString envCfg = dir.filePath("env.ini");
+    const QString cliCfg = dir.filePath("cli.ini");
+    const QString localDb = dir.filePath("local.db");
+
+    {
+        QSettings s(envCfg, QSettings::IniFormat);
+        s.setValue("database/offline", false);
+    }
+    {
+        QSettings s(cliCfg, QSettings::IniFormat);
+        s.setValue("database/offline", true);
+        s.setValue("database/offline_path", localDb);
+    }
+
+    qputenv("NIES_CONFIG_PATH", envCfg.toUtf8());
+    qunsetenv("NIES_DB_OFFLINE");
+    qunsetenv("NIES_DB_OFFLINE_PATH");
+
+    QCommandLineParser parser;
+    QCommandLineOption configOpt("config", "Path to configuration file", "file");
+    parser.addOption(configOpt);
+    parser.process(QStringList{"testapp", "--config", cliCfg});
+
+    DatabaseManager db(parser.value(configOpt));
+    QVERIFY(db.open());
+    QVERIFY(db.isOffline());
+    db.close();
+
+    qunsetenv("NIES_CONFIG_PATH");
+}
+
+#include "config_option_test.moc"

--- a/tests/config_option_test.h
+++ b/tests/config_option_test.h
@@ -1,0 +1,13 @@
+#ifndef CONFIG_OPTION_TEST_H
+#define CONFIG_OPTION_TEST_H
+
+#include <QObject>
+
+class ConfigOptionTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void cliOverridesEnv();
+};
+
+#endif // CONFIG_OPTION_TEST_H

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -15,6 +15,7 @@
 #include "dashboard_window_test.h"
 #include "stock_prediction_test.h"
 #include "user_window_test.h"
+#include "config_option_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -748,6 +749,8 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&dashboardTest, argc, argv);
     UserWindowTest userWinTest;
     status |= QTest::qExec(&userWinTest, argc, argv);
+    ConfigOptionTest configOptTest;
+    status |= QTest::qExec(&configOptTest, argc, argv);
     StockPredictionTest stockTest;
     status |= QTest::qExec(&stockTest, argc, argv);
     return status;


### PR DESCRIPTION
## Summary
- allow passing configuration file via `--config`
- document the CLI option
- add test for command-line config path precedence

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687c3de49a9c8328afdc38ccd6f2353e