### PR TITLE
Add Dashboard menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Le projet en est à ses débuts. Les composants suivants sont disponibles :
 * Paiements numériques (cartes, mobile money, QR codes). Les transactions sont actuellement simulées.
 * Rapports financiers détaillés et calcul des bénéfices.
 * Tableaux de bord avec indicateurs clés (ventes, niveaux de stock).
+  Une entrée de menu **Dashboard** permet maintenant d'ouvrir ce tableau de bord
+  à tout moment.
 * Prédiction de stock et alertes de seuil critique.
 * Support multi‑utilisateurs connecté à une base de données partagée.
 * Gestion de sessions utilisateur avec vérification des rôles lors des

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -3,9 +3,11 @@
 #include "sales/POSWindow.h"
 #include "sales/SalesReportWindow.h"
 #include "login/UserWindow.h"
+#include "dashboard/DashboardWindow.h"
 #include "UserManager.h"
 #include "ProductManager.h"
 #include "SalesManager.h"
+#include "InventoryManager.h"
 #include "UserSession.h"
 #include <QMenuBar>
 #include <QMenu>
@@ -35,6 +37,10 @@ MainWindow::MainWindow(UserSession *session, QWidget *parent)
     m_usersAct = userMenu->addAction(tr("Manage Users"));
     m_usersAct->setObjectName("usersAct");
     connect(m_usersAct, &QAction::triggered, this, &MainWindow::openUsers);
+
+    m_dashboardAct = menuBar()->addAction(tr("Dashboard"));
+    m_dashboardAct->setObjectName("dashboardAct");
+    connect(m_dashboardAct, &QAction::triggered, this, &MainWindow::openDashboard);
 
     updatePermissions();
 }
@@ -75,6 +81,17 @@ void MainWindow::openUsers()
     m_userWindow->activateWindow();
 }
 
+void MainWindow::openDashboard()
+{
+    if (!m_dashboardWindow)
+        m_dashboardWindow = new DashboardWindow(new SalesManager(m_session, this),
+                                               new InventoryManager(m_session, this),
+                                               60000, this);
+    m_dashboardWindow->show();
+    m_dashboardWindow->raise();
+    m_dashboardWindow->activateWindow();
+}
+
 void MainWindow::updatePermissions()
 {
     const QString role = m_session ? m_session->role() : QString();
@@ -86,5 +103,6 @@ void MainWindow::updatePermissions()
         m_reportAct->setEnabled(false);
     if (role != "admin")
         m_usersAct->setEnabled(false);
+    m_dashboardAct->setEnabled(!role.isEmpty());
 }
 

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -6,6 +6,7 @@
 class ProductWindow;
 class POSWindow;
 class SalesReportWindow;
+class DashboardWindow;
 class UserWindow;
 class UserSession;
 class QAction;
@@ -21,6 +22,7 @@ private slots:
     void openPOS();
     void openReport();
     void openUsers();
+    void openDashboard();
 
 private:
     void updatePermissions();
@@ -29,9 +31,11 @@ private:
     QAction *m_posAct = nullptr;
     QAction *m_reportAct = nullptr;
     QAction *m_usersAct = nullptr;
+    QAction *m_dashboardAct = nullptr;
     ProductWindow *m_productWindow = nullptr;
     POSWindow *m_posWindow = nullptr;
     SalesReportWindow *m_reportWindow = nullptr;
+    DashboardWindow *m_dashboardWindow = nullptr;
     UserWindow *m_userWindow = nullptr;
 };
 

--- a/tests/main_window_test.cpp
+++ b/tests/main_window_test.cpp
@@ -8,6 +8,7 @@
 #include "UserSession.h"
 #include "main_window_test.h"
 #include <QAction>
+#include "dashboard/DashboardWindow.h"
 
 static void setupUsersTable()
 {
@@ -96,6 +97,27 @@ void MainWindowTest::viewerNoAccess()
     QVERIFY(manageAct && posAct);
     QVERIFY(!manageAct->isEnabled());
     QVERIFY(!posAct->isEnabled());
+}
+
+void MainWindowTest::dashboardActionOpens()
+{
+    ScopedDb scoped;
+    UserManager um;
+    UserSession session(&um, &um);
+    QVERIFY(um.createUser("dash", "pw", "seller"));
+    QVERIFY(session.login("dash", "pw"));
+
+    MainWindow win(&session);
+    win.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&win));
+
+    QAction *dashAct = win.findChild<QAction*>("dashboardAct");
+    QVERIFY(dashAct);
+    QVERIFY(dashAct->isEnabled());
+    QVERIFY(!win.findChild<DashboardWindow*>());
+    dashAct->trigger();
+    DashboardWindow *dash = win.findChild<DashboardWindow*>();
+    QVERIFY(dash && dash->isVisible());
 }
 
 

--- a/tests/main_window_test.h
+++ b/tests/main_window_test.h
@@ -10,6 +10,7 @@ private slots:
     void adminFullAccess();
     void sellerLimitedAccess();
     void viewerNoAccess();
+    void dashboardActionOpens();
 };
 
 #endif // MAIN_WINDOW_TEST_H


### PR DESCRIPTION
## Summary
- open Dashboard from MainWindow
- ensure dashboard menu item enabled for all roles
- add regression test for new menu
- document Dashboard menu entry

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687c426652188328ba627182f5f9e75e