### PR TITLE
Integrate stock predictions view

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(NieSApp
     invoices/InvoicePrinter.cpp
     payments/PaymentProcessor.cpp
     stock/StockPrediction.cpp
+    stock/StockPredictionWindow.cpp
     sales/POSWindow.cpp
     sales/SalesReportWindow.cpp
     dashboard/DashboardWindow.cpp

--- a/src/login/MainWindow.cpp
+++ b/src/login/MainWindow.cpp
@@ -4,6 +4,7 @@
 #include "sales/SalesReportWindow.h"
 #include "login/UserWindow.h"
 #include "dashboard/DashboardWindow.h"
+#include "stock/StockPredictionWindow.h"
 #include "UserManager.h"
 #include "ProductManager.h"
 #include "SalesManager.h"
@@ -38,9 +39,15 @@ MainWindow::MainWindow(UserSession *session, QWidget *parent)
     m_usersAct->setObjectName("usersAct");
     connect(m_usersAct, &QAction::triggered, this, &MainWindow::openUsers);
 
+
     m_dashboardAct = menuBar()->addAction(tr("Dashboard"));
     m_dashboardAct->setObjectName("dashboardAct");
     connect(m_dashboardAct, &QAction::triggered, this, &MainWindow::openDashboard);
+
+    QMenu *stockMenu = menuBar()->addMenu(tr("Stock"));
+    m_predictAct = stockMenu->addAction(tr("Predictions"));
+    m_predictAct->setObjectName("predictAct");
+    connect(m_predictAct, &QAction::triggered, this, &MainWindow::openPredictions);
 
     updatePermissions();
 }
@@ -92,6 +99,17 @@ void MainWindow::openDashboard()
     m_dashboardWindow->activateWindow();
 }
 
+void MainWindow::openPredictions()
+{
+    if (!m_predictionWindow)
+        m_predictionWindow = new StockPredictionWindow(new SalesManager(m_session, this),
+                                                       new InventoryManager(m_session, this),
+                                                       this);
+    m_predictionWindow->show();
+    m_predictionWindow->raise();
+    m_predictionWindow->activateWindow();
+}
+
 void MainWindow::updatePermissions()
 {
     const QString role = m_session ? m_session->role() : QString();
@@ -104,5 +122,7 @@ void MainWindow::updatePermissions()
     if (role != "admin")
         m_usersAct->setEnabled(false);
     m_dashboardAct->setEnabled(!role.isEmpty());
+    if (m_predictAct)
+        m_predictAct->setEnabled(!role.isEmpty());
 }
 

--- a/src/login/MainWindow.h
+++ b/src/login/MainWindow.h
@@ -7,6 +7,7 @@ class ProductWindow;
 class POSWindow;
 class SalesReportWindow;
 class DashboardWindow;
+class StockPredictionWindow;
 class UserWindow;
 class UserSession;
 class QAction;
@@ -23,6 +24,7 @@ private slots:
     void openReport();
     void openUsers();
     void openDashboard();
+    void openPredictions();
 
 private:
     void updatePermissions();
@@ -32,10 +34,12 @@ private:
     QAction *m_reportAct = nullptr;
     QAction *m_usersAct = nullptr;
     QAction *m_dashboardAct = nullptr;
+    QAction *m_predictAct = nullptr;
     ProductWindow *m_productWindow = nullptr;
     POSWindow *m_posWindow = nullptr;
     SalesReportWindow *m_reportWindow = nullptr;
     DashboardWindow *m_dashboardWindow = nullptr;
+    StockPredictionWindow *m_predictionWindow = nullptr;
     UserWindow *m_userWindow = nullptr;
 };
 

--- a/src/stock/StockPredictionWindow.cpp
+++ b/src/stock/StockPredictionWindow.cpp
@@ -1,0 +1,52 @@
+#include "stock/StockPredictionWindow.h"
+#include <QListWidget>
+#include <QVBoxLayout>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlDatabase>
+#include "SalesManager.h"
+#include "InventoryManager.h"
+
+StockPredictionWindow::StockPredictionWindow(SalesManager *sm, InventoryManager *im, QWidget *parent)
+    : QWidget(parent), m_sm(sm), m_im(im), m_list(new QListWidget(this))
+{
+    setWindowTitle(tr("Stock Predictions"));
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addWidget(m_list);
+
+    connect(&m_timer, &QTimer::timeout, this, &StockPredictionWindow::refreshPredictions);
+    m_timer.start(60000);
+
+    if (m_sm)
+        connect(m_sm, SIGNAL(saleRecorded(int,int)), this, SLOT(refreshPredictions()));
+    if (m_im)
+        connect(m_im, SIGNAL(stockChanged(int,int)), this, SLOT(refreshPredictions()));
+
+    refreshPredictions();
+}
+
+void StockPredictionWindow::refreshPredictions()
+{
+    if (!m_list)
+        return;
+
+    m_list->clear();
+
+    QSqlDatabase db = QSqlDatabase::database();
+    if (!db.isOpen())
+        return;
+
+    QSqlQuery q(db);
+    if (!q.exec("SELECT id, name FROM products"))
+        return;
+
+    while (q.next()) {
+        int pid = q.value(0).toInt();
+        QString name = q.value(1).toString();
+        int pred = m_prediction.predict(pid);
+        bool crit = m_prediction.isCritical(pid, 5);
+        QString text = tr("%1: predicted %2").arg(name).arg(pred);
+        if (crit)
+            text += tr(" - Low stock");
+        m_list->addItem(text);
+    }
+}

--- a/src/stock/StockPredictionWindow.h
+++ b/src/stock/StockPredictionWindow.h
@@ -1,0 +1,31 @@
+#ifndef STOCKPREDICTIONWINDOW_H
+#define STOCKPREDICTIONWINDOW_H
+
+#include <QWidget>
+#include <QTimer>
+#include "stock/StockPrediction.h"
+
+class QListWidget;
+class SalesManager;
+class InventoryManager;
+
+class StockPredictionWindow : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit StockPredictionWindow(SalesManager *sm = nullptr,
+                                   InventoryManager *im = nullptr,
+                                   QWidget *parent = nullptr);
+
+public slots:
+    void refreshPredictions();
+
+private:
+    StockPrediction m_prediction;
+    SalesManager *m_sm;
+    InventoryManager *m_im;
+    QListWidget *m_list;
+    QTimer m_timer;
+};
+
+#endif // STOCKPREDICTIONWINDOW_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/invoices/InvoicePrinter.cpp
     ${CMAKE_SOURCE_DIR}/src/payments/PaymentProcessor.cpp
     ${CMAKE_SOURCE_DIR}/src/stock/StockPrediction.cpp
+    ${CMAKE_SOURCE_DIR}/src/stock/StockPredictionWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/dashboard/DashboardWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/login/LoginDialog.cpp
     ${CMAKE_SOURCE_DIR}/src/login/MainWindow.cpp

--- a/tests/main_window_test.cpp
+++ b/tests/main_window_test.cpp
@@ -9,6 +9,7 @@
 #include "main_window_test.h"
 #include <QAction>
 #include "dashboard/DashboardWindow.h"
+#include "stock/StockPredictionWindow.h"
 
 static void setupUsersTable()
 {
@@ -118,6 +119,27 @@ void MainWindowTest::dashboardActionOpens()
     dashAct->trigger();
     DashboardWindow *dash = win.findChild<DashboardWindow*>();
     QVERIFY(dash && dash->isVisible());
+}
+
+void MainWindowTest::predictionActionOpens()
+{
+    ScopedDb scoped;
+    UserManager um;
+    UserSession session(&um, &um);
+    QVERIFY(um.createUser("pred", "pw", "seller"));
+    QVERIFY(session.login("pred", "pw"));
+
+    MainWindow win(&session);
+    win.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&win));
+
+    QAction *predAct = win.findChild<QAction*>("predictAct");
+    QVERIFY(predAct);
+    QVERIFY(predAct->isEnabled());
+    QVERIFY(!win.findChild<StockPredictionWindow*>());
+    predAct->trigger();
+    StockPredictionWindow *predWin = win.findChild<StockPredictionWindow*>();
+    QVERIFY(predWin && predWin->isVisible());
 }
 
 

--- a/tests/main_window_test.h
+++ b/tests/main_window_test.h
@@ -11,6 +11,7 @@ private slots:
     void sellerLimitedAccess();
     void viewerNoAccess();
     void dashboardActionOpens();
+    void predictionActionOpens();
 };
 
 #endif // MAIN_WINDOW_TEST_H


### PR DESCRIPTION
## Summary
- implement new `StockPredictionWindow` displaying predicted stock levels
- hook window to the main menu via new *Stock > Predictions* action
- update permissions and tests for the new action

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687c4d19451483288f15da78ad0d3e51