### PR TITLE
Fix wrong source path in qmake project file

### DIFF
--- a/NieSApp.pro
+++ b/NieSApp.pro
@@ -12,7 +12,7 @@ SOURCES += \
     src/SalesManager.cpp \
     src/UserSession.cpp \
     src/login/LoginDialog.cpp \
-    src/login/MainWindow.cppn\
+    src/login/MainWindow.cpp \
     src/NetworkMonitor.cpp
 
 HEADERS += \


### PR DESCRIPTION
## Summary
- fix typo in `NieSApp.pro` so qmake sees `src/login/MainWindow.cpp`

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`
- `qmake NieSApp.pro -o Makefile && make -j2` *(fails: stock prediction header missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c50bcf304832899db931ec7e92703