### PR TITLE
Add JSON backup and restore utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ connection settings via environment variables:
 - `NIES_DB_PASSWORD` – database password
 - `NIES_DB_DRIVER` – Qt SQL driver (e.g. `QMYSQL`, `QSQLITE`)
 - `NIES_DB_OFFLINE_PATH` – path to the offline SQLite file
+- `NIES_DB_BACKUP_PATH` – location of the JSON backup file
 - `NIES_LANG` – override the UI language (e.g. `fr_FR`)
 - `NIES_DASH_INTERVAL` – dashboard refresh interval in milliseconds
 
@@ -110,6 +111,11 @@ The application now includes a small `NetworkMonitor` helper that listens for
 changes in network connectivity. When offline mode is enabled and the network
 becomes available again, `DatabaseManager` automatically triggers
 `synchronize()` so pending rows are uploaded without manual intervention.
+
+`DatabaseManager` can also export a full backup of the current data set with
+`exportBackup()` and reload it later using `restoreBackup()`. Set
+`NIES_DB_BACKUP_PATH` to choose where this JSON backup is stored. Calling
+`synchronize()` while online simply generates the backup file.
 
 Example using environment variables:
 

--- a/config.example.ini
+++ b/config.example.ini
@@ -11,6 +11,8 @@ password=your_password
 offline=false
 # Path to the SQLite file used in offline mode
 offline_path=nies_local.db
+# Path to the JSON backup file used for export/restore
+backup_path=nies_backup.json
 
 [payment]
 # Endpoint URL of the payment gateway

--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -15,6 +15,8 @@ public:
 
     bool open();
     bool synchronize();
+    bool exportBackup(const QString &filePath = QString());
+    bool restoreBackup(const QString &filePath = QString());
     void close();
     QString lastError() const;
     bool isOffline() const { return m_offline; }
@@ -27,6 +29,7 @@ private:
     QSettings m_settings;
     bool m_offline = false;
     QString m_offlinePath;
+    QString m_backupPath;
     QString m_driver = "QMYSQL";
     QString m_paymentApiKey;
     QString m_paymentEndpoint;


### PR DESCRIPTION
## Summary
- expose backup/restore in `DatabaseManager`
- load `backup_path` from config/environment
- export JSON backups in `synchronize()`
- restore backups when opening in offline mode
- document backup support in README and config example

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687cbe451b9c8328a787b4f0b65cb9fd