### PR TITLE
Add simple REST API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ make
 ./NieSApp
 ```
 
+### REST API server
+
+An optional HTTP server exposes product and sales data as a small REST API.
+Build the `NieSApi` target and launch it (default port `8080`):
+
+```bash
+mkdir build && cd build
+cmake ..
+make NieSApi
+./NieSApi
+```
+
+Available endpoints:
+
+- `GET /products` – list products
+- `POST /products` – JSON body `{"name": ..., "price": ..., "discount": 0.0}`
+- `GET /sales` – list recorded sales
+- `POST /sales` – JSON body `{"product_id": ..., "quantity": ...}`
+
+
 Before running, duplicate `config.example.ini` as `config.ini` and configure
 your database parameters. `DatabaseManager` looks for this file next to the
 executable by default. You may specify a custom location with the

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.5)
+project(NieSApi LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt5 COMPONENTS Core Network Sql REQUIRED)
+
+add_executable(NieSApi
+    main.cpp
+    RestServer.cpp
+    ../DatabaseManager.cpp
+    ../ProductManager.cpp
+    ../InventoryManager.cpp
+    ../SalesManager.cpp
+    ../UserSession.cpp
+)
+
+target_include_directories(NieSApi PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(NieSApi Qt5::Core Qt5::Network Qt5::Sql)

--- a/src/api/RestServer.cpp
+++ b/src/api/RestServer.cpp
@@ -1,0 +1,90 @@
+#include "RestServer.h"
+#include "DatabaseManager.h"
+#include "ProductManager.h"
+#include "SalesManager.h"
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QHostAddress>
+#include <QVariantMap>
+#include <QDebug>
+
+RestServer::RestServer(QObject *parent)
+    : QObject(parent), m_server(new QTcpServer(this)),
+      m_db(new DatabaseManager(QString(), this)),
+      m_products(new ProductManager(nullptr, this)),
+      m_sales(new SalesManager(nullptr, this))
+{
+    if (!m_db->open())
+        qWarning() << "Database open failed:" << m_db->lastError();
+}
+
+static QJsonArray variantListToJson(const QList<QVariantMap> &list)
+{
+    QJsonArray arr;
+    for (const QVariantMap &m : list)
+        arr.append(QJsonObject::fromVariantMap(m));
+    return arr;
+}
+
+bool RestServer::start(quint16 port)
+{
+    connect(m_server, &QTcpServer::newConnection, this, &RestServer::handleConnection);
+    if (!m_server->listen(QHostAddress::Any, port))
+        return false;
+    qInfo() << "REST server listening on port" << port;
+    return true;
+}
+
+void RestServer::handleConnection()
+{
+    QTcpSocket *socket = m_server->nextPendingConnection();
+    connect(socket, &QTcpSocket::readyRead, this, [=]() {
+        QByteArray request = socket->readAll();
+        QList<QByteArray> lines = request.split('\n');
+        if (lines.isEmpty()) {
+            socket->disconnectFromHost();
+            return;
+        }
+        QByteArray requestLine = lines.first().trimmed();
+        QList<QByteArray> parts = requestLine.split(' ');
+        QByteArray method = parts.value(0);
+        QByteArray path = parts.value(1);
+        int bodyIndex = request.indexOf("\r\n\r\n");
+        QByteArray body = bodyIndex != -1 ? request.mid(bodyIndex + 4) : QByteArray();
+
+        QByteArray response;
+        if (method == "GET" && path == "/products") {
+            QJsonArray arr = variantListToJson(m_products->listProducts());
+            QByteArray json = QJsonDocument(arr).toJson();
+            response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+                       + QByteArray::number(json.size()) + "\r\n\r\n" + json;
+        } else if (method == "POST" && path == "/products") {
+            QJsonObject obj = QJsonDocument::fromJson(body).object();
+            QString name = obj.value("name").toString();
+            double price = obj.value("price").toDouble();
+            double discount = obj.value("discount").toDouble();
+            bool ok = m_products->addProduct(name, price, discount);
+            response = QByteArray("HTTP/1.1 ") + (ok ? "201 Created" : "500 Internal Server Error")
+                    + "\r\n\r\n";
+        } else if (method == "GET" && path == "/sales") {
+            QJsonArray arr = variantListToJson(m_sales->salesReport());
+            QByteArray json = QJsonDocument(arr).toJson();
+            response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+                       + QByteArray::number(json.size()) + "\r\n\r\n" + json;
+        } else if (method == "POST" && path == "/sales") {
+            QJsonObject obj = QJsonDocument::fromJson(body).object();
+            int pid = obj.value("product_id").toInt();
+            int qty = obj.value("quantity").toInt();
+            bool ok = m_sales->recordSale(pid, qty);
+            response = QByteArray("HTTP/1.1 ") + (ok ? "201 Created" : "500 Internal Server Error")
+                    + "\r\n\r\n";
+        } else {
+            response = "HTTP/1.1 404 Not Found\r\n\r\n";
+        }
+        socket->write(response);
+        socket->disconnectFromHost();
+    });
+}

--- a/src/api/RestServer.h
+++ b/src/api/RestServer.h
@@ -1,0 +1,28 @@
+#ifndef RESTSERVER_H
+#define RESTSERVER_H
+
+#include <QObject>
+
+class QTcpServer;
+class QTcpSocket;
+class DatabaseManager;
+class ProductManager;
+class SalesManager;
+
+class RestServer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RestServer(QObject *parent = nullptr);
+    bool start(quint16 port = 8080);
+
+private:
+    void handleConnection();
+
+    QTcpServer *m_server;
+    DatabaseManager *m_db;
+    ProductManager *m_products;
+    SalesManager *m_sales;
+};
+
+#endif // RESTSERVER_H

--- a/src/api/main.cpp
+++ b/src/api/main.cpp
@@ -1,0 +1,16 @@
+#include <QCoreApplication>
+#include <QDebug>
+#include "RestServer.h"
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    RestServer server;
+    if (!server.start(8080)) {
+        qCritical("Failed to start REST server");
+        return 1;
+    }
+
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- add a minimal REST server under `src/api`
- expose product and sales endpoints
- document REST API usage in the README

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687cc0a695bc8328aa733f2389f19eaa