### PR TITLE
Add QML mobile client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(NieS LANGUAGES CXX)
 
 add_subdirectory(src)
 add_subdirectory(examples/connectdb)
+add_subdirectory(mobile)
 
 enable_testing()
 add_subdirectory(tests)

--- a/mobile/CMakeLists.txt
+++ b/mobile/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5)
+project(NieSMobile LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt5 COMPONENTS Quick Network REQUIRED)
+
+add_executable(NieSMobile
+    main.cpp
+    RestClient.cpp
+    qml.qrc
+)
+
+target_include_directories(NieSMobile PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(NieSMobile Qt5::Quick Qt5::Network)

--- a/mobile/RestClient.cpp
+++ b/mobile/RestClient.cpp
@@ -1,0 +1,53 @@
+#include "RestClient.h"
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QVariantList>
+
+RestClient::RestClient(const QUrl &baseUrl, QObject *parent)
+    : QObject(parent), m_mgr(new QNetworkAccessManager(this)), m_baseUrl(baseUrl)
+{
+}
+
+void RestClient::setBaseUrl(const QUrl &url)
+{
+    if (m_baseUrl == url)
+        return;
+    m_baseUrl = url;
+    emit baseUrlChanged();
+}
+
+void RestClient::fetchProducts()
+{
+    QNetworkRequest req(m_baseUrl.resolved(QUrl("/products")));
+    QNetworkReply *reply = m_mgr->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        QByteArray data = reply->readAll();
+        reply->deleteLater();
+        QJsonParseError err;
+        QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+        if (err.error != QJsonParseError::NoError || !doc.isArray()) {
+            emit productsReceived({});
+            return;
+        }
+        QVariantList list = doc.array().toVariantList();
+        emit productsReceived(list);
+    });
+}
+
+void RestClient::postSale(int productId, int quantity)
+{
+    QNetworkRequest req(m_baseUrl.resolved(QUrl("/sales")));
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+    QJsonObject obj{{"product_id", productId}, {"quantity", quantity}};
+    QNetworkReply *reply = m_mgr->post(req, QJsonDocument(obj).toJson());
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        bool ok = reply->error() == QNetworkReply::NoError;
+        QString err = ok ? QString() : reply->errorString();
+        reply->deleteLater();
+        emit saleFinished(ok, err);
+    });
+}

--- a/mobile/RestClient.h
+++ b/mobile/RestClient.h
@@ -1,0 +1,32 @@
+#ifndef RESTCLIENT_H
+#define RESTCLIENT_H
+
+#include <QObject>
+#include <QUrl>
+
+class QNetworkAccessManager;
+
+class RestClient : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QUrl baseUrl READ baseUrl WRITE setBaseUrl NOTIFY baseUrlChanged)
+public:
+    explicit RestClient(const QUrl &baseUrl = QUrl("http://localhost:8080"), QObject *parent = nullptr);
+
+    QUrl baseUrl() const { return m_baseUrl; }
+    void setBaseUrl(const QUrl &url);
+
+    Q_INVOKABLE void fetchProducts();
+    Q_INVOKABLE void postSale(int productId, int quantity);
+
+signals:
+    void baseUrlChanged();
+    void productsReceived(const QVariantList &products);
+    void saleFinished(bool success, const QString &error);
+
+private:
+    QNetworkAccessManager *m_mgr;
+    QUrl m_baseUrl;
+};
+
+#endif // RESTCLIENT_H

--- a/mobile/main.cpp
+++ b/mobile/main.cpp
@@ -1,0 +1,20 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include "RestClient.h"
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication app(argc, argv);
+
+    RestClient client;
+
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty("restClient", &client);
+    engine.load(QUrl(QStringLiteral("qrc:/qml/Main.qml")));
+
+    if (engine.rootObjects().isEmpty())
+        return -1;
+
+    return app.exec();
+}

--- a/mobile/qml.qrc
+++ b/mobile/qml.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>qml/Main.qml</file>
+    </qresource>
+</RCC>

--- a/mobile/qml/Main.qml
+++ b/mobile/qml/Main.qml
@@ -1,0 +1,49 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.5
+
+ApplicationWindow {
+    visible: true
+    width: 360
+    height: 640
+    title: qsTr("NieS Mobile")
+
+    ListModel {
+        id: productModel
+    }
+
+    Component.onCompleted: restClient.fetchProducts()
+
+    Connections {
+        target: restClient
+        onProductsReceived: {
+            productModel.clear()
+            for (var i = 0; i < products.length; ++i)
+                productModel.append(products[i])
+        }
+        onSaleFinished: function(success, err) {
+            if (success)
+                console.log("Sale recorded")
+            else
+                console.log("Sale error: " + err)
+        }
+    }
+
+    ListView {
+        anchors.fill: parent
+        model: productModel
+        delegate: Item {
+            width: parent.width
+            height: 50
+            Row {
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 10
+                Text { text: name; width: 150 }
+                Text { text: "$" + price; width: 60 }
+                Button {
+                    text: qsTr("Sell")
+                    onClicked: restClient.postSale(id, 1)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add QML client under `mobile/`
- hook mobile build into root CMake
- implement `RestClient` to talk to REST API
- basic QML UI to list products and post sales

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687cc4d28f0c832891b6d82f2ab5a8e0