### PR TITLE
Improve REST server configuration

### DIFF
--- a/CAHIER_DE_CHARGE.md
+++ b/CAHIER_DE_CHARGE.md
@@ -22,6 +22,7 @@ Concevoir une application de gestion moderne pour boutique ou restaurant. Elle d
 - Programme de fidélité et cartes de membres.
 - Application mobile compagnon pour consultation et notifications.
 - API REST pour intégration e-commerce et systèmes tiers.
+- Port du serveur REST configurable via `--port` ou `NIES_REST_PORT`.
 - Gestion du personnel (planning et feuilles de paie).
 - Inventaire par codes-barres ou QR codes.
 - Interface multi-langues pour une portée internationale.
@@ -29,6 +30,7 @@ Concevoir une application de gestion moderne pour boutique ou restaurant. Elle d
 ## Aspects techniques
 
 - Base de données **MySQL** avec scripts de migration.
+- Pilote SQL configurable (`QMYSQL` ou `QSQLITE`).
 - Interface **Qt** (Widgets ou QML) pour le poste de travail et terminaux mobiles.
 - Architecture modulaire séparant interface, logique métier et accès aux données.
 - Sécurité renforcée : mots de passe hachés et contrôle des accès.

--- a/PROJECT_PROGRES.md
+++ b/PROJECT_PROGRES.md
@@ -15,7 +15,8 @@
 ### Nouvelles tâches
 - [ ] Améliorer l\'UI d\'authentification
 - [ ] Intégrer les paiements numériques *(PaymentProcessor ne fait qu\'une simulation – intégration d\'une passerelle réelle nécessaire)*
-- [ ] Générer un tableau de bord complet *(DashboardWindow n\'affiche encore qu\'un texte temporaire)*
+- [x] Générer un tableau de bord complet
+- [ ] Ajouter une option `--port` et la variable `NIES_REST_PORT` pour le serveur REST
 - [ ] Prédiction de stock et de ventes *(module `StockPrediction` basique, pas encore relié à l\'interface)*
 - [ ] Système de sauvegarde et synchronisation
 - [ ] API REST pour intégration e-commerce

--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ make
 ### REST API server
 
 An optional HTTP server exposes product and sales data as a small REST API.
-Build the `NieSApi` target and launch it (default port `8080`):
+Build the `NieSApi` target and launch it. The listening port can be
+specified with `--port` or the `NIES_REST_PORT` variable (default `8080`):
 
 ```bash
 mkdir build && cd build
 cmake ..
 make NieSApi
-./NieSApi
+./NieSApi --port 8080
 ```
 
 Available endpoints:
@@ -113,6 +114,7 @@ connection settings via environment variables:
 - `NIES_DB_DRIVER` – Qt SQL driver (e.g. `QMYSQL`, `QSQLITE`)
 - `NIES_DB_OFFLINE_PATH` – path to the offline SQLite file
 - `NIES_DB_BACKUP_PATH` – location of the JSON backup file
+- `NIES_REST_PORT` – REST server port when running `NieSApi`
 - `NIES_LANG` – override the UI language (e.g. `fr_FR`)
 - `NIES_DASH_INTERVAL` – dashboard refresh interval in milliseconds
 

--- a/config.example.ini
+++ b/config.example.ini
@@ -7,6 +7,8 @@ port=3306
 name=your_db
 user=your_user
 password=your_password
+# SQL driver to use (e.g. QMYSQL or QSQLITE)
+driver=QMYSQL
 # Set to true to use a local SQLite file when MySQL is unavailable
 offline=false
 # Path to the SQLite file used in offline mode

--- a/src/api/main.cpp
+++ b/src/api/main.cpp
@@ -1,13 +1,29 @@
 #include <QCoreApplication>
 #include <QDebug>
+#include <QCommandLineParser>
+#include <QProcessEnvironment>
 #include "RestServer.h"
 
 int main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
 
+    QCommandLineParser parser;
+    parser.addHelpOption();
+    QCommandLineOption portOpt(QStringList{"p", "port"},
+                               "Port to listen on", "port");
+    parser.addOption(portOpt);
+    parser.process(app);
+
+    int port = 8080;
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    if (env.contains("NIES_REST_PORT"))
+        port = env.value("NIES_REST_PORT").toInt();
+    if (parser.isSet(portOpt))
+        port = parser.value(portOpt).toInt();
+
     RestServer server;
-    if (!server.start(8080)) {
+    if (!server.start(static_cast<quint16>(port))) {
         qCritical("Failed to start REST server");
         return 1;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     return_manager_test.cpp
     invoice_printer_test.cpp
     payment_processor_test.cpp
+    rest_server_test.cpp
     dashboard_window_test.cpp
     stock_prediction_test.cpp
     loyalty_manager_test.cpp
@@ -38,6 +39,7 @@ set(TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/login/LoginDialog.cpp
     ${CMAKE_SOURCE_DIR}/src/login/MainWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/login/UserWindow.cpp
+    ${CMAKE_SOURCE_DIR}/src/api/RestServer.cpp
     ${CMAKE_SOURCE_DIR}/src/UserSession.cpp
 )
 

--- a/tests/rest_server_test.cpp
+++ b/tests/rest_server_test.cpp
@@ -1,0 +1,24 @@
+#include <QtTest>
+#include <QApplication>
+#include <QTcpSocket>
+#include "api/RestServer.h"
+#include "rest_server_test.h"
+
+void RestServerTest::startAndRespond()
+{
+    RestServer server;
+    QVERIFY(server.start(12345));
+
+    QTcpSocket sock;
+    sock.connectToHost("127.0.0.1", 12345);
+    QVERIFY(sock.waitForConnected());
+
+    QByteArray req = "GET /bad HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    QVERIFY(sock.write(req) == req.size());
+    QVERIFY(sock.waitForBytesWritten());
+    QVERIFY(sock.waitForReadyRead());
+    QByteArray resp = sock.readAll();
+    QVERIFY(resp.startsWith("HTTP/1.1 404"));
+}
+
+#include "rest_server_test.moc"

--- a/tests/rest_server_test.h
+++ b/tests/rest_server_test.h
@@ -1,0 +1,13 @@
+#ifndef REST_SERVER_TEST_H
+#define REST_SERVER_TEST_H
+
+#include <QObject>
+
+class RestServerTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void startAndRespond();
+};
+
+#endif // REST_SERVER_TEST_H


### PR DESCRIPTION
## Summary
- add configurable port for the REST server via `--port` option or `NIES_REST_PORT`
- document REST server port option and DB driver in config example
- update CAHIER_DE_CHARGE and project progress
- add unit test for `RestServer`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687ccd5d59d083289aecd66cdcbbfdc6