### PR TITLE
Connect RestServer sockets to deleteLater

### DIFF
--- a/src/api/RestServer.cpp
+++ b/src/api/RestServer.cpp
@@ -41,6 +41,7 @@ bool RestServer::start(quint16 port)
 void RestServer::handleConnection()
 {
     QTcpSocket *socket = m_server->nextPendingConnection();
+    connect(socket, &QTcpSocket::disconnected, socket, &QTcpSocket::deleteLater);
     connect(socket, &QTcpSocket::readyRead, this, [=]() {
         QByteArray request = socket->readAll();
         QList<QByteArray> lines = request.split('\n');


### PR DESCRIPTION
## Summary
- ensure sockets are cleaned up after they disconnect in RestServer

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687cd5f48ea88328838649e56955a22f