### PR TITLE
Add Qt Charts to CI deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ qtbase5-dev qttools5-dev qttools5-dev-tools libqt5sql5 libqt5sql5-psql
+          sudo apt-get install -y cmake g++ qtbase5-dev qttools5-dev qttools5-dev-tools libqt5sql5 libqt5sql5-psql libqt5charts5-dev
       - name: Configure
         run: cmake -B build -S .
       - name: Build


### PR DESCRIPTION
## Summary
- install `libqt5charts5-dev` in CI

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687cddfebb1883289683d48dd2143032