### PR TITLE
Update FR translations and regenerate QM

### DIFF
--- a/translations/NieS_fr.ts
+++ b/translations/NieS_fr.ts
@@ -4,199 +4,391 @@
 <context>
     <name>DashboardWindow</name>
     <message>
-        <location filename="src/dashboard/DashboardWindow.cpp" line="10"/>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="22"/>
         <source>Dashboard</source>
         <translation>Tableau de bord</translation>
     </message>
     <message>
-        <location filename="src/dashboard/DashboardWindow.cpp" line="12"/>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="38"/>
+        <source>Daily Revenue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="44"/>
+        <source>Inventory Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="86"/>
+        <source>Total revenue: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="88"/>
+        <source>Units sold: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="90"/>
+        <source>Stock on hand: %1</source>
+        <translation>Stock disponible : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="96"/>
+        <source>Revenue</source>
+        <translation>Revenu</translation>
+    </message>
+    <message>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="144"/>
+        <source>%1: predicted %2</source>
+        <translation>%1 : prévu %2</translation>
+    </message>
+    <message>
+        <location filename="../src/dashboard/DashboardWindow.cpp" line="146"/>
+        <source> - Low stock</source>
+        <translation> - Stock faible</translation>
+    </message>
+    <message>
         <source>Sales and inventory KPIs will be shown here.</source>
-        <translation>Les indicateurs de vente et de stock seront affichés ici.</translation>
+        <translation type="vanished">Les indicateurs de vente et de stock seront affichés ici.</translation>
     </message>
 </context>
 <context>
     <name>LoginDialog</name>
     <message>
-        <location filename="src/login/LoginDialog.cpp" line="14"/>
-        <location filename="src/login/LoginDialog.cpp" line="20"/>
+        <location filename="../src/login/LoginDialog.cpp" line="14"/>
+        <location filename="../src/login/LoginDialog.cpp" line="20"/>
         <source>Login</source>
         <translation>Connexion</translation>
     </message>
     <message>
-        <location filename="src/login/LoginDialog.cpp" line="24"/>
+        <location filename="../src/login/LoginDialog.cpp" line="24"/>
         <source>Username</source>
-        <translation>Nom d'utilisateur</translation>
+        <translation>Nom d&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="src/login/LoginDialog.cpp" line="25"/>
+        <location filename="../src/login/LoginDialog.cpp" line="25"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location filename="src/login/LoginDialog.cpp" line="46"/>
+        <location filename="../src/login/LoginDialog.cpp" line="47"/>
         <source>Login failed</source>
         <translation>Échec de la connexion</translation>
     </message>
 </context>
 <context>
+    <name>LoyaltyManager</name>
+    <message>
+        <location filename="../src/loyalty/LoyaltyManager.cpp" line="51"/>
+        <source>Insufficient points</source>
+        <translation>Points insuffisants</translation>
+    </message>
+</context>
+<context>
+    <name>LoyaltyWindow</name>
+    <message>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="17"/>
+        <source>Loyalty Accounts</source>
+        <translation>Comptes fidélité</translation>
+    </message>
+    <message>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="22"/>
+        <source>ID</source>
+        <translation type="unfinished">ID</translation>
+    </message>
+    <message>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="22"/>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="41"/>
+        <source>Phone</source>
+        <translation>Téléphone</translation>
+    </message>
+    <message>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="22"/>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="42"/>
+        <source>Points</source>
+        <translation>Points</translation>
+    </message>
+    <message>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="35"/>
+        <source>Add Account</source>
+        <translation>Ajouter un compte</translation>
+    </message>
+    <message>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="36"/>
+        <source>Apply Points</source>
+        <translation>Appliquer les points</translation>
+    </message>
+    <message>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="78"/>
+        <location filename="../src/loyalty/LoyaltyWindow.cpp" line="95"/>
+        <source>Error</source>
+        <translation type="unfinished">Erreur</translation>
+    </message>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
-        <location filename="src/login/MainWindow.cpp" line="16"/>
+        <location filename="../src/login/MainWindow.cpp" line="23"/>
         <source>NieS</source>
         <translation>NieS</translation>
     </message>
     <message>
-        <location filename="src/login/MainWindow.cpp" line="18"/>
+        <location filename="../src/login/MainWindow.cpp" line="25"/>
         <source>Products</source>
         <translation>Produits</translation>
     </message>
     <message>
-        <location filename="src/login/MainWindow.cpp" line="19"/>
+        <location filename="../src/login/MainWindow.cpp" line="26"/>
         <source>Manage Products</source>
         <translation>Gérer les produits</translation>
     </message>
     <message>
-        <location filename="src/login/MainWindow.cpp" line="23"/>
+        <location filename="../src/login/MainWindow.cpp" line="30"/>
         <source>Sales</source>
         <translation>Ventes</translation>
     </message>
     <message>
-        <location filename="src/login/MainWindow.cpp" line="24"/>
+        <location filename="../src/login/MainWindow.cpp" line="31"/>
         <source>Point of Sale</source>
         <translation>Point de vente</translation>
     </message>
     <message>
-        <location filename="src/login/MainWindow.cpp" line="28"/>
+        <location filename="../src/login/MainWindow.cpp" line="35"/>
         <source>Sales Report</source>
         <translation>Rapport des ventes</translation>
+    </message>
+    <message>
+        <location filename="../src/login/MainWindow.cpp" line="39"/>
+        <source>Loyalty</source>
+        <translation>Fidélité</translation>
+    </message>
+    <message>
+        <location filename="../src/login/MainWindow.cpp" line="43"/>
+        <source>Users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/login/MainWindow.cpp" line="44"/>
+        <source>Manage Users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/login/MainWindow.cpp" line="49"/>
+        <source>Dashboard</source>
+        <translation type="unfinished">Tableau de bord</translation>
+    </message>
+    <message>
+        <location filename="../src/login/MainWindow.cpp" line="53"/>
+        <source>Stock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/login/MainWindow.cpp" line="54"/>
+        <source>Predictions</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>POSWindow</name>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="20"/>
-        <location filename="src/sales/POSWindow.cpp" line="95"/>
+        <location filename="../src/sales/POSWindow.cpp" line="35"/>
+        <location filename="../src/sales/POSWindow.cpp" line="123"/>
+        <location filename="../src/sales/POSWindow.cpp" line="127"/>
+        <location filename="../src/sales/POSWindow.cpp" line="140"/>
         <source>Return</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="21"/>
+        <location filename="../src/sales/POSWindow.cpp" line="36"/>
         <source>Print Invoice</source>
         <translation>Imprimer la facture</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="26"/>
+        <location filename="../src/sales/POSWindow.cpp" line="41"/>
         <source>Point of Sale</source>
         <translation>Point de vente</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="36"/>
+        <location filename="../src/sales/POSWindow.cpp" line="54"/>
         <source>Sell</source>
         <translation>Vendre</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="40"/>
+        <location filename="../src/sales/POSWindow.cpp" line="58"/>
         <source>Cash</source>
         <translation>Espèces</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="40"/>
-        <location filename="src/sales/POSWindow.cpp" line="83"/>
+        <location filename="../src/sales/POSWindow.cpp" line="58"/>
+        <location filename="../src/sales/POSWindow.cpp" line="109"/>
         <source>Card</source>
         <translation>Carte</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="40"/>
-        <location filename="src/sales/POSWindow.cpp" line="85"/>
+        <location filename="../src/sales/POSWindow.cpp" line="58"/>
+        <location filename="../src/sales/POSWindow.cpp" line="111"/>
         <source>Mobile Money</source>
         <translation>Mobile money</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="40"/>
-        <location filename="src/sales/POSWindow.cpp" line="87"/>
+        <location filename="../src/sales/POSWindow.cpp" line="58"/>
+        <location filename="../src/sales/POSWindow.cpp" line="113"/>
         <source>QR Code</source>
         <translation>Code QR</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="46"/>
+        <location filename="../src/sales/POSWindow.cpp" line="64"/>
         <source>Product</source>
         <translation>Produit</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="47"/>
+        <location filename="../src/sales/POSWindow.cpp" line="65"/>
+        <location filename="../src/sales/POSWindow.cpp" line="127"/>
         <source>Quantity</source>
         <translation>Quantité</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="78"/>
+        <location filename="../src/sales/POSWindow.cpp" line="66"/>
+        <source>Loyalty Phone</source>
+        <translation>Téléphone fidélité</translation>
+    </message>
+    <message>
+        <location filename="../src/sales/POSWindow.cpp" line="105"/>
+        <location filename="../src/sales/POSWindow.cpp" line="132"/>
+        <location filename="../src/sales/POSWindow.cpp" line="147"/>
+        <location filename="../src/sales/POSWindow.cpp" line="152"/>
+        <location filename="../src/sales/POSWindow.cpp" line="161"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="95"/>
+        <location filename="../src/sales/POSWindow.cpp" line="116"/>
+        <source>sale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sales/POSWindow.cpp" line="123"/>
+        <source>Sale ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sales/POSWindow.cpp" line="137"/>
+        <source>return</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sales/POSWindow.cpp" line="140"/>
         <source>Return processed.</source>
         <translation>Retour traité.</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="100"/>
+        <location filename="../src/sales/POSWindow.cpp" line="152"/>
+        <source>No sales recorded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sales/POSWindow.cpp" line="165"/>
         <source>Invoice</source>
         <translation>Facture</translation>
     </message>
     <message>
-        <location filename="src/sales/POSWindow.cpp" line="100"/>
+        <location filename="../src/sales/POSWindow.cpp" line="166"/>
+        <source>Invoice printed to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sales/POSWindow.cpp" line="171"/>
+        <source>Save Invoice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/sales/POSWindow.cpp" line="172"/>
+        <source>Text Files (*.txt);;All Files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invoice printed.</source>
-        <translation>Facture imprimée.</translation>
+        <translation type="vanished">Facture imprimée.</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentProcessor</name>
+    <message>
+        <location filename="../src/payments/PaymentProcessor.cpp" line="50"/>
+        <source>Invalid amount</source>
+        <translation>Montant invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/payments/PaymentProcessor.cpp" line="55"/>
+        <source>Payment endpoint not configured</source>
+        <translation>Point d'accès de paiement non configuré</translation>
+    </message>
+    <message>
+        <location filename="../src/payments/PaymentProcessor.cpp" line="59"/>
+        <source>Missing API key</source>
+        <translation>Clé API manquante</translation>
+    </message>
+    <message>
+        <location filename="../src/payments/PaymentProcessor.cpp" line="84"/>
+        <source>Invalid response</source>
+        <translation>Réponse invalide</translation>
+    </message>
+    <message>
+        <location filename="../src/payments/PaymentProcessor.cpp" line="91"/>
+        <source>Payment failed</source>
+        <translation>Échec du paiement</translation>
     </message>
 </context>
 <context>
     <name>ProductWindow</name>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="17"/>
+        <location filename="../src/products/ProductWindow.cpp" line="17"/>
         <source>Products</source>
         <translation>Produits</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="22"/>
+        <location filename="../src/products/ProductWindow.cpp" line="22"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="22"/>
-        <location filename="src/products/ProductWindow.cpp" line="46"/>
+        <location filename="../src/products/ProductWindow.cpp" line="22"/>
+        <location filename="../src/products/ProductWindow.cpp" line="46"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="22"/>
-        <location filename="src/products/ProductWindow.cpp" line="47"/>
+        <location filename="../src/products/ProductWindow.cpp" line="22"/>
+        <location filename="../src/products/ProductWindow.cpp" line="47"/>
         <source>Price</source>
         <translation>Prix</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="22"/>
-        <location filename="src/products/ProductWindow.cpp" line="48"/>
+        <location filename="../src/products/ProductWindow.cpp" line="22"/>
+        <location filename="../src/products/ProductWindow.cpp" line="48"/>
         <source>Discount</source>
         <translation>Remise</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="37"/>
+        <location filename="../src/products/ProductWindow.cpp" line="37"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="38"/>
+        <location filename="../src/products/ProductWindow.cpp" line="38"/>
         <source>Edit</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="39"/>
+        <location filename="../src/products/ProductWindow.cpp" line="39"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="src/products/ProductWindow.cpp" line="84"/>
-        <location filename="src/products/ProductWindow.cpp" line="100"/>
-        <location filename="src/products/ProductWindow.cpp" line="113"/>
+        <location filename="../src/products/ProductWindow.cpp" line="84"/>
+        <location filename="../src/products/ProductWindow.cpp" line="100"/>
+        <location filename="../src/products/ProductWindow.cpp" line="113"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
@@ -204,34 +396,99 @@
 <context>
     <name>SalesReportWindow</name>
     <message>
-        <location filename="src/sales/SalesReportWindow.cpp" line="12"/>
+        <location filename="../src/sales/SalesReportWindow.cpp" line="12"/>
         <source>Sales Report</source>
         <translation>Rapport des ventes</translation>
     </message>
     <message>
-        <location filename="src/sales/SalesReportWindow.cpp" line="17"/>
+        <location filename="../src/sales/SalesReportWindow.cpp" line="17"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="src/sales/SalesReportWindow.cpp" line="17"/>
+        <location filename="../src/sales/SalesReportWindow.cpp" line="17"/>
         <source>Product ID</source>
         <translation>ID produit</translation>
     </message>
     <message>
-        <location filename="src/sales/SalesReportWindow.cpp" line="17"/>
+        <location filename="../src/sales/SalesReportWindow.cpp" line="17"/>
         <source>Quantity</source>
         <translation>Quantité</translation>
     </message>
     <message>
-        <location filename="src/sales/SalesReportWindow.cpp" line="17"/>
+        <location filename="../src/sales/SalesReportWindow.cpp" line="17"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="src/sales/SalesReportWindow.cpp" line="17"/>
+        <location filename="../src/sales/SalesReportWindow.cpp" line="17"/>
         <source>Total</source>
         <translation>Total</translation>
+    </message>
+</context>
+<context>
+    <name>StockPredictionWindow</name>
+    <message>
+        <location filename="../src/stock/StockPredictionWindow.cpp" line="12"/>
+        <source>Stock Predictions</source>
+        <translation>Prévisions de stock</translation>
+    </message>
+    <message>
+        <location filename="../src/stock/StockPredictionWindow.cpp" line="47"/>
+        <source>%1: predicted %2</source>
+        <translation>%1 : prévu %2</translation>
+    </message>
+    <message>
+        <location filename="../src/stock/StockPredictionWindow.cpp" line="49"/>
+        <source> - Low stock</source>
+        <translation> - Stock faible</translation>
+    </message>
+</context>
+<context>
+    <name>UserWindow</name>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="15"/>
+        <source>Users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="20"/>
+        <location filename="../src/login/UserWindow.cpp" line="43"/>
+        <source>Username</source>
+        <translation type="unfinished">Nom d&apos;utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="20"/>
+        <location filename="../src/login/UserWindow.cpp" line="45"/>
+        <source>Role</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="34"/>
+        <source>Add</source>
+        <translation type="unfinished">Ajouter</translation>
+    </message>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="35"/>
+        <source>Change Role</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="36"/>
+        <source>Delete</source>
+        <translation type="unfinished">Supprimer</translation>
+    </message>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="44"/>
+        <source>Password</source>
+        <translation type="unfinished">Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../src/login/UserWindow.cpp" line="81"/>
+        <location filename="../src/login/UserWindow.cpp" line="97"/>
+        <location filename="../src/login/UserWindow.cpp" line="110"/>
+        <source>Error</source>
+        <translation type="unfinished">Erreur</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary
- refresh translation catalog with `lupdate`
- translate new loyalty, stock prediction, and payment error strings
- verify CMake build produces updated `.qm` file

## Testing
- `cmake -S . -B build`
- `cmake --build build --target translations`


------
https://chatgpt.com/codex/tasks/task_e_687cf009cb20832897bfed34f1c6b3e5