### PR TITLE
Add EmployeeManager and BarcodeScanner modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ add_executable(NieSApp
     login/UserWindow.cpp
     NetworkMonitor.cpp
     UserSession.cpp
+    employees/EmployeeManager.cpp
+    barcode/BarcodeScanner.cpp
 )
 
 target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql Qt5::Network Qt5::Charts)

--- a/src/barcode/BarcodeScanner.cpp
+++ b/src/barcode/BarcodeScanner.cpp
@@ -1,0 +1,12 @@
+#include "barcode/BarcodeScanner.h"
+
+BarcodeScanner::BarcodeScanner(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void BarcodeScanner::scan(const QString &code)
+{
+    emit codeScanned(code);
+}
+

--- a/src/barcode/BarcodeScanner.h
+++ b/src/barcode/BarcodeScanner.h
@@ -1,0 +1,20 @@
+#ifndef BARCODESCANNER_H
+#define BARCODESCANNER_H
+
+#include <QObject>
+#include <QString>
+
+class BarcodeScanner : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BarcodeScanner(QObject *parent = nullptr);
+
+public slots:
+    void scan(const QString &code);
+
+signals:
+    void codeScanned(const QString &code);
+};
+
+#endif // BARCODESCANNER_H

--- a/src/employees/EmployeeManager.cpp
+++ b/src/employees/EmployeeManager.cpp
@@ -1,0 +1,41 @@
+#include "employees/EmployeeManager.h"
+
+EmployeeManager::EmployeeManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void EmployeeManager::setHourlyRate(int employeeId, double rate)
+{
+    m_data[employeeId].rate = rate;
+}
+
+bool EmployeeManager::recordWork(int employeeId, double hours)
+{
+    if (hours < 0)
+        return false;
+    m_data[employeeId].hours += hours;
+    return true;
+}
+
+bool EmployeeManager::scheduleShift(int employeeId, const QDateTime &start, const QDateTime &end)
+{
+    if (!start.isValid() || !end.isValid() || end <= start)
+        return false;
+    m_data[employeeId].schedule.append(qMakePair(start, end));
+    return true;
+}
+
+double EmployeeManager::payroll(int employeeId) const
+{
+    auto it = m_data.find(employeeId);
+    if (it == m_data.end())
+        return 0.0;
+    return it->hours * it->rate;
+}
+
+QList<QPair<QDateTime, QDateTime>> EmployeeManager::shifts(int employeeId) const
+{
+    return m_data.value(employeeId).schedule;
+}
+

--- a/src/employees/EmployeeManager.h
+++ b/src/employees/EmployeeManager.h
@@ -1,0 +1,33 @@
+#ifndef EMPLOYEEMANAGER_H
+#define EMPLOYEEMANAGER_H
+
+#include <QObject>
+#include <QDateTime>
+#include <QHash>
+#include <QList>
+#include <utility>
+
+class EmployeeManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit EmployeeManager(QObject *parent = nullptr);
+
+    void setHourlyRate(int employeeId, double rate);
+    bool recordWork(int employeeId, double hours);
+    bool scheduleShift(int employeeId, const QDateTime &start, const QDateTime &end);
+
+    double payroll(int employeeId) const;
+    QList<QPair<QDateTime, QDateTime>> shifts(int employeeId) const;
+
+private:
+    struct EmployeeInfo {
+        double rate = 0.0;
+        double hours = 0.0;
+        QList<QPair<QDateTime, QDateTime>> schedule;
+    };
+
+    QHash<int, EmployeeInfo> m_data;
+};
+
+#endif // EMPLOYEEMANAGER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ set(TEST_SOURCES
     dashboard_window_test.cpp
     stock_prediction_test.cpp
     loyalty_manager_test.cpp
+    employee_manager_test.cpp
+    barcode_scanner_test.cpp
     config_option_test.cpp
     ${CMAKE_SOURCE_DIR}/src/DatabaseManager.cpp
     ${CMAKE_SOURCE_DIR}/src/UserManager.cpp
@@ -41,6 +43,8 @@ set(TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/login/UserWindow.cpp
     ${CMAKE_SOURCE_DIR}/src/api/RestServer.cpp
     ${CMAKE_SOURCE_DIR}/src/UserSession.cpp
+    ${CMAKE_SOURCE_DIR}/src/employees/EmployeeManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/barcode/BarcodeScanner.cpp
 )
 
 add_executable(nies_tests ${TEST_SOURCES})

--- a/tests/barcode_scanner_test.cpp
+++ b/tests/barcode_scanner_test.cpp
@@ -1,0 +1,14 @@
+#include <QtTest>
+#include <QSignalSpy>
+#include "barcode/BarcodeScanner.h"
+#include "barcode_scanner_test.h"
+
+void BarcodeScannerTest::emitsSignal()
+{
+    BarcodeScanner scanner;
+    QSignalSpy spy(&scanner, &BarcodeScanner::codeScanned);
+    scanner.scan("12345");
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.takeFirst().at(0).toString(), QString("12345"));
+}
+

--- a/tests/barcode_scanner_test.h
+++ b/tests/barcode_scanner_test.h
@@ -1,0 +1,13 @@
+#ifndef BARCODE_SCANNER_TEST_H
+#define BARCODE_SCANNER_TEST_H
+
+#include <QObject>
+
+class BarcodeScannerTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void emitsSignal();
+};
+
+#endif // BARCODE_SCANNER_TEST_H

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -16,6 +16,8 @@
 #include "stock_prediction_test.h"
 #include "user_window_test.h"
 #include "config_option_test.h"
+#include "employee_manager_test.h"
+#include "barcode_scanner_test.h"
 #include <QTemporaryDir>
 #include <QProcess>
 #include <QRandomGenerator>
@@ -753,6 +755,10 @@ int main(int argc, char *argv[])
     status |= QTest::qExec(&configOptTest, argc, argv);
     StockPredictionTest stockTest;
     status |= QTest::qExec(&stockTest, argc, argv);
+    EmployeeManagerTest employeeTest;
+    status |= QTest::qExec(&employeeTest, argc, argv);
+    BarcodeScannerTest barcodeTest;
+    status |= QTest::qExec(&barcodeTest, argc, argv);
     return status;
 }
 

--- a/tests/employee_manager_test.cpp
+++ b/tests/employee_manager_test.cpp
@@ -1,0 +1,19 @@
+#include <QtTest>
+#include "employees/EmployeeManager.h"
+#include "employee_manager_test.h"
+
+void EmployeeManagerTest::payrollZeroByDefault()
+{
+    EmployeeManager mgr;
+    QCOMPARE(mgr.payroll(1), 0.0);
+}
+
+void EmployeeManagerTest::schedulingAddsShift()
+{
+    EmployeeManager mgr;
+    QDateTime start = QDateTime::currentDateTime();
+    QDateTime end = start.addSecs(3600);
+    QVERIFY(mgr.scheduleShift(1, start, end));
+    QCOMPARE(mgr.shifts(1).size(), 1);
+}
+

--- a/tests/employee_manager_test.h
+++ b/tests/employee_manager_test.h
@@ -1,0 +1,14 @@
+#ifndef EMPLOYEE_MANAGER_TEST_H
+#define EMPLOYEE_MANAGER_TEST_H
+
+#include <QObject>
+
+class EmployeeManagerTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void payrollZeroByDefault();
+    void schedulingAddsShift();
+};
+
+#endif // EMPLOYEE_MANAGER_TEST_H


### PR DESCRIPTION
## Summary
- add `EmployeeManager` for scheduling and payroll management
- add `BarcodeScanner` interface using Qt signals
- hook new modules into build system
- provide unit tests for creating an employee manager and barcode scanning

## Testing
- `cmake ..`
- `make translations`
- `cmake --build . -- -j1`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687cf232f2148328864c8ebb4af1a892