### PR TITLE
Add login dialog enhancements

### DIFF
--- a/src/login/LoginDialog.cpp
+++ b/src/login/LoginDialog.cpp
@@ -2,36 +2,69 @@
 #include "UserSession.h"
 #include <QLineEdit>
 #include <QPushButton>
+#include <QCheckBox>
+#include <QLabel>
 #include <QFormLayout>
 #include <QVBoxLayout>
 #include <QMessageBox>
+#include <QPixmap>
 
-LoginDialog::LoginDialog(UserSession *session, QWidget *parent, bool showErrors)
+LoginDialog::LoginDialog(UserSession *session, QWidget *parent, bool showErrors,
+                         const QPixmap &logo)
     : QDialog(parent),
       m_session(session),
       m_showErrors(showErrors)
 {
     setWindowTitle(tr("Login"));
 
+    m_logoLabel = new QLabel(this);
+    if (!logo.isNull()) {
+        m_logoLabel->setPixmap(logo);
+        m_logoLabel->setAlignment(Qt::AlignCenter);
+    } else {
+        m_logoLabel->setVisible(false);
+    }
+
     m_usernameEdit = new QLineEdit(this);
+    m_usernameEdit->setObjectName("usernameEdit");
+    m_usernameEdit->setPlaceholderText(tr("Username"));
     m_passwordEdit = new QLineEdit(this);
+    m_passwordEdit->setObjectName("passwordEdit");
+    m_passwordEdit->setPlaceholderText(tr("Password"));
     m_passwordEdit->setEchoMode(QLineEdit::Password);
 
+    m_showPassCheck = new QCheckBox(tr("Show Password"), this);
+    m_showPassCheck->setObjectName("showPassCheck");
+    connect(m_showPassCheck, &QCheckBox::toggled,
+            this, &LoginDialog::onTogglePassword);
+
     m_loginButton = new QPushButton(tr("Login"), this);
+    m_loginButton->setObjectName("loginButton");
     connect(m_loginButton, &QPushButton::clicked, this, &LoginDialog::onLoginClicked);
 
     QFormLayout *form = new QFormLayout;
+    form->setSpacing(10);
     form->addRow(tr("Username"), m_usernameEdit);
     form->addRow(tr("Password"), m_passwordEdit);
 
     QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->setSpacing(15);
+    layout->setContentsMargins(20, 20, 20, 20);
+    if (!logo.isNull())
+        layout->addWidget(m_logoLabel);
     layout->addLayout(form);
+    layout->addWidget(m_showPassCheck);
     layout->addWidget(m_loginButton);
 }
 
 void LoginDialog::onLoginClicked()
 {
     attemptLogin(m_usernameEdit->text(), m_passwordEdit->text());
+}
+
+void LoginDialog::onTogglePassword(bool checked)
+{
+    m_passwordEdit->setEchoMode(checked ? QLineEdit::Normal : QLineEdit::Password);
 }
 
 bool LoginDialog::attemptLogin(const QString &username, const QString &password)

--- a/src/login/LoginDialog.h
+++ b/src/login/LoginDialog.h
@@ -2,16 +2,21 @@
 #define LOGINDIALOG_H
 
 #include <QDialog>
+#include <QPixmap>
 
 class QLineEdit;
 class QPushButton;
+class QCheckBox;
+class QLabel;
+class QPixmap;
 class UserSession;
 
 class LoginDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit LoginDialog(UserSession *session, QWidget *parent = nullptr, bool showErrors = true);
+    explicit LoginDialog(UserSession *session, QWidget *parent = nullptr,
+                         bool showErrors = true, const QPixmap &logo = QPixmap());
 
     bool attemptLogin(const QString &username, const QString &password);
 
@@ -20,12 +25,15 @@ signals:
 
 private slots:
     void onLoginClicked();
+    void onTogglePassword(bool checked);
 
 private:
     UserSession *m_session;
     QLineEdit *m_usernameEdit;
     QLineEdit *m_passwordEdit;
     QPushButton *m_loginButton;
+    QCheckBox *m_showPassCheck;
+    QLabel *m_logoLabel;
     bool m_showErrors;
 };
 

--- a/tests/login_test.cpp
+++ b/tests/login_test.cpp
@@ -6,6 +6,8 @@
 #include "UserManager.h"
 #include "UserSession.h"
 #include "login_test.h"
+#include <QLineEdit>
+#include <QCheckBox>
 
 void LoginDialogTest::invalidCredentials()
 {
@@ -63,5 +65,23 @@ void LoginDialogTest::validCredentials()
 
     db.close();
     QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+
+void LoginDialogTest::togglePasswordVisibility()
+{
+    LoginDialog dlg(nullptr, nullptr, false);
+    dlg.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&dlg));
+
+    auto passEdit = dlg.findChild<QLineEdit*>("passwordEdit");
+    auto check = dlg.findChild<QCheckBox*>("showPassCheck");
+    QVERIFY(passEdit && check);
+    QCOMPARE(passEdit->echoMode(), QLineEdit::Password);
+
+    check->setChecked(true);
+    QCOMPARE(passEdit->echoMode(), QLineEdit::Normal);
+
+    check->setChecked(false);
+    QCOMPARE(passEdit->echoMode(), QLineEdit::Password);
 }
 

--- a/tests/login_test.h
+++ b/tests/login_test.h
@@ -9,6 +9,7 @@ class LoginDialogTest : public QObject
 private slots:
     void invalidCredentials();
     void validCredentials();
+    void togglePasswordVisibility();
 };
 
 #endif // LOGIN_TEST_H


### PR DESCRIPTION
## Summary
- enhance `LoginDialog` with placeholders and password visibility toggle
- support optional logo and adjust spacing
- test password visibility

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687d0e9764a08328856e8e9fc287445f