### PR TITLE
Update build instructions for Qt Charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Les prochaines étapes concerneront l'amélioration de l'ergonomie et des tests 
 * Exemple concret d’intégration Qt/C++ avec MySQL (connexion, requêtes, gestion des erreurs).
 
 ## Build and Run
-Ensure Qt 5 (or later) with Widgets and SQL modules is installed.
+Ensure Qt 5 (or later) with Widgets, Charts, and SQL modules is installed.
 
 ```
 mkdir build && cd build


### PR DESCRIPTION
## Summary
- document that Qt Charts is required alongside Widgets and SQL

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt5Charts")*

------
https://chatgpt.com/codex/tasks/task_e_687d5a8efa0c83289d862c582114037c