### PR TITLE
Change sendRequest to protected

### DIFF
--- a/src/payments/PaymentProcessor.h
+++ b/src/payments/PaymentProcessor.h
@@ -26,8 +26,10 @@ public:
 
     QString lastError() const;
 
-private:
+protected:
     virtual bool sendRequest(const QString &method, double amount);
+
+private:
     QString m_lastError;
     QNetworkAccessManager *m_manager;
     QString m_apiKey;


### PR DESCRIPTION
## Summary
- change `sendRequest` method visibility in `PaymentProcessor` to `protected`
- rebuild and run the unit tests

## Testing
- `cmake ..`
- `make -j$(nproc) nies_tests`
- `./tests/nies_tests`

------
https://chatgpt.com/codex/tasks/task_e_687d5c21c2d48328867cf92f9f893e31