### PR TITLE
Fix EmployeeManager recordWork error handling

### DIFF
--- a/src/employees/EmployeeManager.cpp
+++ b/src/employees/EmployeeManager.cpp
@@ -32,8 +32,10 @@ void EmployeeManager::setHourlyRate(int employeeId, double rate)
 
 bool EmployeeManager::recordWork(int employeeId, double hours)
 {
-    if (hours < 0)
+    if (hours < 0) {
+        m_lastError = QStringLiteral("Invalid hours");
         return false;
+    }
     QSqlQuery q;
     q.prepare("SELECT hours_worked FROM employees WHERE id=?");
     q.addBindValue(employeeId);

--- a/tests/employee_manager_test.cpp
+++ b/tests/employee_manager_test.cpp
@@ -76,3 +76,21 @@ void EmployeeManagerTest::recordWorkPersists()
     QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
 }
 
+void EmployeeManagerTest::recordWorkRejectsNegative()
+{
+    if (QSqlDatabase::contains(QSqlDatabase::defaultConnection))
+        QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+    db.setDatabaseName(":memory:");
+    QVERIFY(db.open());
+
+    setupTables();
+
+    EmployeeManager mgr;
+    QVERIFY(!mgr.recordWork(1, -3));
+    QCOMPARE(mgr.lastError(), QString("Invalid hours"));
+
+    db.close();
+    QSqlDatabase::removeDatabase(QSqlDatabase::defaultConnection);
+}
+

--- a/tests/employee_manager_test.h
+++ b/tests/employee_manager_test.h
@@ -10,6 +10,7 @@ private slots:
     void payrollZeroByDefault();
     void schedulingAddsShift();
     void recordWorkPersists();
+    void recordWorkRejectsNegative();
 };
 
 #endif // EMPLOYEE_MANAGER_TEST_H


### PR DESCRIPTION
## Summary
- set `m_lastError` when calling `recordWork` with negative hours
- test for negative hours

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687d5dcb39fc83288051a0fab137c586