### PR TITLE
Fix include path for NetworkMonitor

### DIFF
--- a/src/NetworkMonitor.h
+++ b/src/NetworkMonitor.h
@@ -2,7 +2,7 @@
 #define NETWORKMONITOR_H
 
 #include <QObject>
-#include <QtNetwork/QNetworkConfigurationManager>
+#include <QNetworkConfigurationManager>
 
 class NetworkMonitor : public QObject
 {


### PR DESCRIPTION
## Summary
- include `QNetworkConfigurationManager` with the correct Qt header

## Testing
- `cmake ..` *(fails: Qt5 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d64f73d308328a0fe62496add7eb5