### PR TITLE
Update network monitor to use QNetworkInformation

### DIFF
--- a/NieSApp.pro
+++ b/NieSApp.pro
@@ -1,4 +1,5 @@
 QT += widgets sql network charts
+qtHaveModule(networkinformation): QT += networkinformation
 CONFIG += c++11 console
 TEMPLATE = app
 TARGET = NieSApp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,13 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt5 COMPONENTS Widgets Sql Network LinguistTools Charts REQUIRED)
+find_package(Qt6 COMPONENTS Widgets Sql Network NetworkInformation LinguistTools Charts)
+if(Qt6_FOUND)
+    set(QT_PACKAGE Qt6)
+else()
+    find_package(Qt5 COMPONENTS Widgets Sql Network LinguistTools Charts REQUIRED)
+    set(QT_PACKAGE Qt5)
+endif()
 
 add_executable(NieSApp
     main.cpp
@@ -36,13 +42,20 @@ add_executable(NieSApp
     barcode/BarcodeScanner.cpp
 )
 
-target_link_libraries(NieSApp Qt5::Widgets Qt5::Sql Qt5::Network Qt5::Charts)
+target_link_libraries(NieSApp ${QT_PACKAGE}::Widgets ${QT_PACKAGE}::Sql ${QT_PACKAGE}::Network ${QT_PACKAGE}::Charts)
+if(Qt6_FOUND)
+    target_link_libraries(NieSApp Qt6::NetworkInformation)
+endif()
 target_include_directories(NieSApp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(TS_FILES
     ${CMAKE_SOURCE_DIR}/translations/NieS_fr.ts
 )
-qt5_add_translation(QM_FILES ${TS_FILES})
+if(Qt6_FOUND)
+    qt6_add_translation(QM_FILES ${TS_FILES})
+else()
+    qt5_add_translation(QM_FILES ${TS_FILES})
+endif()
 add_custom_target(translations ALL DEPENDS ${QM_FILES})
 
 add_custom_command(TARGET NieSApp POST_BUILD

--- a/src/NetworkMonitor.cpp
+++ b/src/NetworkMonitor.cpp
@@ -1,8 +1,42 @@
 #include "NetworkMonitor.h"
 
 NetworkMonitor::NetworkMonitor(QObject *parent)
-    : QObject(parent),
-      m_isOnline(m_manager.isOnline())
+    : QObject(parent)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+    , m_info(QNetworkInformation::instance())
+    , m_reachability(m_info->reachability())
+#else
+    , m_isOnline(m_manager.isOnline())
+    , m_reachability(m_isOnline ? Reachability::Online : Reachability::Disconnected)
+#endif
+{
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+
+void NetworkMonitor::startMonitoring()
+{
+    connect(m_info, &QNetworkInformation::reachabilityChanged, this, [this](QNetworkInformation::Reachability r){
+        if (m_reachability == r)
+            return;
+        m_reachability = r;
+        emit networkStatusChanged(r);
+    });
+}
+
+NetworkMonitor::Reachability NetworkMonitor::reachability() const
+{
+    return m_reachability;
+}
+
+bool NetworkMonitor::isOnline() const
+{
+    return m_reachability != QNetworkInformation::Reachability::Disconnected;
+}
+
+#else
+
+void NetworkMonitor::startMonitoring()
 {
     connect(&m_manager, &QNetworkConfigurationManager::onlineStateChanged,
             this, &NetworkMonitor::handleOnlineStateChanged);
@@ -13,5 +47,18 @@ void NetworkMonitor::handleOnlineStateChanged(bool isOnline)
     if (m_isOnline == isOnline)
         return;
     m_isOnline = isOnline;
-    emit connectivityChanged(m_isOnline);
+    m_reachability = m_isOnline ? Reachability::Online : Reachability::Disconnected;
+    emit networkStatusChanged(m_reachability);
 }
+
+NetworkMonitor::Reachability NetworkMonitor::reachability() const
+{
+    return m_reachability;
+}
+
+bool NetworkMonitor::isOnline() const
+{
+    return m_isOnline;
+}
+
+#endif

--- a/src/NetworkMonitor.h
+++ b/src/NetworkMonitor.h
@@ -2,24 +2,46 @@
 #define NETWORKMONITOR_H
 
 #include <QObject>
-#include <QNetworkConfigurationManager>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+#  include <QNetworkInformation>
+#else
+#  include <QNetworkConfigurationManager>
+#endif
 
 class NetworkMonitor : public QObject
 {
     Q_OBJECT
 public:
     explicit NetworkMonitor(QObject *parent = nullptr);
-    bool isOnline() const { return m_isOnline; }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+    using Reachability = QNetworkInformation::Reachability;
+#else
+    enum class Reachability { Unknown, Disconnected, Local, Site, Online };
+#endif
+
+    Reachability reachability() const;
+    bool isOnline() const;
+
+    void startMonitoring();
 
 signals:
-    void connectivityChanged(bool online);
+    void networkStatusChanged(Reachability reachability);
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
 private slots:
     void handleOnlineStateChanged(bool isOnline);
+#endif
 
 private:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+    QNetworkInformation *m_info;
+    Reachability m_reachability;
+#else
     QNetworkConfigurationManager m_manager;
     bool m_isOnline;
+    Reachability m_reachability;
+#endif
 };
 
 #endif // NETWORKMONITOR_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,9 +71,10 @@ int main(int argc, char *argv[])
     }
 
     NetworkMonitor monitor;
-    QObject::connect(&monitor, &NetworkMonitor::connectivityChanged,
-                     [&db](bool online) {
-        if (online && db.isOffline())
+    monitor.startMonitoring();
+    QObject::connect(&monitor, &NetworkMonitor::networkStatusChanged,
+                     [&db](NetworkMonitor::Reachability r) {
+        if (r != NetworkMonitor::Reachability::Disconnected && db.isOffline())
             db.synchronize();
     });
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5 COMPONENTS Test Sql Widgets Network Charts REQUIRED)
+find_package(Qt6 COMPONENTS Test Sql Widgets Network NetworkInformation Charts)
+if(Qt6_FOUND)
+    set(QT_PACKAGE Qt6)
+else()
+    find_package(Qt5 COMPONENTS Test Sql Widgets Network Charts REQUIRED)
+    set(QT_PACKAGE Qt5)
+endif()
 
 set(TEST_SOURCES
     database_test.cpp
@@ -55,6 +61,9 @@ add_executable(nies_tests ${TEST_SOURCES})
 
 target_include_directories(nies_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
-target_link_libraries(nies_tests Qt5::Test Qt5::Sql Qt5::Widgets Qt5::Network Qt5::Charts)
+target_link_libraries(nies_tests ${QT_PACKAGE}::Test ${QT_PACKAGE}::Sql ${QT_PACKAGE}::Widgets ${QT_PACKAGE}::Network ${QT_PACKAGE}::Charts)
+if(Qt6_FOUND)
+    target_link_libraries(nies_tests Qt6::NetworkInformation)
+endif()
 
 add_test(NAME NieSTests COMMAND nies_tests)


### PR DESCRIPTION
## Summary
- replace deprecated QNetworkConfigurationManager usage with QNetworkInformation when available
- expose new API returning reachability and emitting a signal when network status changes
- adjust main application to use new monitor API
- update build files to link against Qt NetworkInformation when possible with backwards compatibility

## Testing
- `qmake NieSApp.pro -o Makefile-qt5`
- `make -f Makefile-qt5` *(fails: linking issues)*
- `cmake ..`
- `cmake --build .` *(fails: Error copying translations)*

------
https://chatgpt.com/codex/tasks/task_e_687d6fc6b6248328bb20e9bea7cb515e