### PR TITLE
Gather .pro sources with files()

### DIFF
--- a/NieSApp.pro
+++ b/NieSApp.pro
@@ -5,60 +5,13 @@ TEMPLATE = app
 TARGET = NieSApp
 INCLUDEPATH += $$PWD/src
 
-SOURCES += \
-    src/main.cpp \
-    src/DatabaseManager.cpp \
-    src/UserManager.cpp \
-    src/ProductManager.cpp \
-    src/InventoryManager.cpp \
-    src/SalesManager.cpp \
-    src/loyalty/LoyaltyManager.cpp \
-    src/loyalty/LoyaltyWindow.cpp \
-    src/UserSession.cpp \
-    src/login/LoginDialog.cpp \
-    src/login/MainWindow.cpp \
-    src/NetworkMonitor.cpp \
-    src/products/ProductWindow.cpp \
-    src/inventory/InventoryWindow.cpp \
-    src/returns/ReturnManager.cpp \
-    src/invoices/InvoicePrinter.cpp \
-    src/payments/PaymentProcessor.cpp \
-    src/stock/StockPrediction.cpp \
-    src/stock/StockPredictionWindow.cpp \
-    src/sales/POSWindow.cpp \
-    src/sales/SalesReportWindow.cpp \
-    src/dashboard/DashboardWindow.cpp \
-    src/login/UserWindow.cpp \
-    src/employees/EmployeeWindow.cpp \
-    src/employees/EmployeeManager.cpp \
-    src/barcode/BarcodeScanner.cpp
+# Automatically include all C++ source files found under src/
+# This uses the qmake files() function with recursive search to avoid
+# manually updating the project file whenever a new file is added.
+SOURCES += $$files($$PWD/src/*.cpp, true)
 
-HEADERS += \
-    src/DatabaseManager.h \
-    src/UserManager.h \
-    src/ProductManager.h \
-    src/InventoryManager.h \
-    src/SalesManager.h \
-    src/loyalty/LoyaltyManager.h \
-    src/loyalty/LoyaltyWindow.h \
-    src/UserSession.h \
-    src/login/LoginDialog.h \
-    src/login/MainWindow.h\
-    src/NetworkMonitor.h \
-    src/products/ProductWindow.h \
-    src/inventory/InventoryWindow.h \
-    src/returns/ReturnManager.h \
-    src/invoices/InvoicePrinter.h \
-    src/payments/PaymentProcessor.h \
-    src/stock/StockPrediction.h \
-    src/stock/StockPredictionWindow.h \
-    src/sales/POSWindow.h \
-    src/sales/SalesReportWindow.h \
-    src/dashboard/DashboardWindow.h \
-    src/login/UserWindow.h \
-    src/employees/EmployeeWindow.h \
-    src/employees/EmployeeManager.h \
-    src/barcode/BarcodeScanner.h
+# Collect header files recursively as well
+HEADERS += $$files($$PWD/src/*.h, true)
 
 # Include config file for convenience
 OTHER_FILES += config.ini


### PR DESCRIPTION
## Summary
- use `qmake` `files()` function to automatically collect cpp/h files
- note this in NieSApp.pro comments

## Testing
- `cmake ..` *(fails: Could not find Qt5ChartsConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_687d77f03f1883288e0373a916f9abb1