### PR TITLE
Align qmake project with CMake modules

### DIFF
--- a/NieSApp.pro
+++ b/NieSApp.pro
@@ -15,3 +15,6 @@ HEADERS += $$files($$PWD/src/*.h, true)
 
 # Include config file for convenience
 OTHER_FILES += config.ini
+
+# Translation files for internationalization
+TRANSLATIONS += translations/NieS_fr.ts


### PR DESCRIPTION
## Summary
- reference translation file in `NieSApp.pro`
- ensure qmake project matches modules and resources defined in `src/CMakeLists.txt`

## Testing
- `cmake ..` *(fails: could not find Qt6 or Qt5Charts)*

------
https://chatgpt.com/codex/tasks/task_e_687d791ec4208328a0e5f7766fe8e4eb