### PR TITLE
Fix QtCharts include for DashboardWindow

### DIFF
--- a/src/dashboard/DashboardWindow.cpp
+++ b/src/dashboard/DashboardWindow.cpp
@@ -9,6 +9,7 @@
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlDatabase>
 #include <QStringList>
+#include <QtCharts/QChart>
 #include <QtCharts/QChartView>
 #include <QtCharts/QBarSeries>
 #include <QtCharts/QBarSet>


### PR DESCRIPTION
## Summary
- include `<QtCharts/QChart>` to resolve build errors in DashboardWindow

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_687d7b746a688328933ca549fb1a4b0c