### PR TITLE
Remove API code from desktop qmake build

### DIFF
--- a/NieSApp.pro
+++ b/NieSApp.pro
@@ -10,6 +10,10 @@ INCLUDEPATH += $$PWD/src
 # manually updating the project file whenever a new file is added.
 SOURCES += $$files($$PWD/src/*.cpp, true)
 
+# Remove API server sources from the desktop build
+SOURCES -= $$files($$PWD/src/api/*.cpp, true)
+HEADERS -= $$files($$PWD/src/api/*.h, true)
+
 # Collect header files recursively as well
 HEADERS += $$files($$PWD/src/*.h, true)
 


### PR DESCRIPTION
## Summary
- update `NieSApp.pro` to exclude API server sources
- regenerate qmake build files to confirm only one `main.cpp` is compiled

## Testing
- `qmake ../NieSApp.pro`
- `make -n | grep main.cpp`
- `make -n | grep 'src/api/main.cpp'`

------
https://chatgpt.com/codex/tasks/task_e_687d80ccaf5083289dc3a48e0e1675f7