### PR TITLE
Fix SalesManager member order

### DIFF
--- a/src/SalesManager.h
+++ b/src/SalesManager.h
@@ -25,8 +25,8 @@ signals:
 
 private:
     QString m_lastError;
-    InventoryManager m_inventory;
     UserSession *m_session = nullptr;
+    InventoryManager m_inventory;
 };
 
 #endif // SALESMANAGER_H


### PR DESCRIPTION
## Summary
- reorder private members in `SalesManager` so `m_session` comes before `m_inventory`
- confirm constructor initializes members in this order

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687d817ae4d88328bd6e55cda1875c12