### PR TITLE
Fix QtCharts includes in DashboardWindow

### DIFF
--- a/src/dashboard/DashboardWindow.h
+++ b/src/dashboard/DashboardWindow.h
@@ -4,7 +4,10 @@
 #include <QWidget>
 #include <QTimer>
 #include <QtCharts/QChartView>
+#include <QtCharts/QChart>
 #include <QtCharts/QBarSeries>
+#include <QtCharts/QBarSet>
+#include <QtCharts/QBarCategoryAxis>
 #include <QtCharts/QPieSeries>
 
 class QListWidget;
@@ -14,12 +17,6 @@ class SalesManager;
 class InventoryManager;
 
 class QLabel;
-
-namespace QtCharts {
-class QChartView;
-class QBarSeries;
-class QPieSeries;
-}
 
 class DashboardWindow : public QWidget
 {


### PR DESCRIPTION
## Summary
- include QtCharts headers directly instead of using forward declarations
- remove now unnecessary forward declarations

## Testing
- `cmake ..`
- `make translations`
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_687d82f65b748328b88fe453ce555881