### PR TITLE
Fix DashboardWindow build errors

### DIFF
--- a/src/dashboard/DashboardWindow.cpp
+++ b/src/dashboard/DashboardWindow.cpp
@@ -16,7 +16,7 @@
 #include <QtCharts/QBarCategoryAxis>
 #include <QtCharts/QPieSeries>
 
-QT_CHARTS_USE_NAMESPACE
+using namespace QtCharts;
 
 DashboardWindow::DashboardWindow(SalesManager *sm, InventoryManager *im,
                                  int interval, QWidget *parent)

--- a/src/dashboard/DashboardWindow.h
+++ b/src/dashboard/DashboardWindow.h
@@ -9,10 +9,9 @@
 #include <QtCharts/QBarSet>
 #include <QtCharts/QBarCategoryAxis>
 #include <QtCharts/QPieSeries>
+#include <QListWidget>
 
-QT_CHARTS_USE_NAMESPACE
-
-class QListWidget;
+using namespace QtCharts;
 #include "stock/StockPrediction.h"
 
 class SalesManager;


### PR DESCRIPTION
## Summary
- fix missing QListWidget include for dashboard UI
- remove undefined QT_CHARTS_USE_NAMESPACE macro
- use QtCharts namespace explicitly

## Testing
- `cmake ..` *(fails: Could not find Qt6 or Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_687d8e8e995c83288252938622c11215