### PR TITLE
Fix QtCharts includes

### DIFF
--- a/src/dashboard/DashboardWindow.cpp
+++ b/src/dashboard/DashboardWindow.cpp
@@ -9,6 +9,7 @@
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlDatabase>
 #include <QStringList>
+#include <QtCharts/QChartGlobal>
 #include <QtCharts/QChart>
 #include <QtCharts/QChartView>
 #include <QtCharts/QBarSeries>
@@ -16,7 +17,7 @@
 #include <QtCharts/QBarCategoryAxis>
 #include <QtCharts/QPieSeries>
 
-using namespace QtCharts;
+QT_CHARTS_USE_NAMESPACE
 
 DashboardWindow::DashboardWindow(SalesManager *sm, InventoryManager *im,
                                  int interval, QWidget *parent)

--- a/src/dashboard/DashboardWindow.h
+++ b/src/dashboard/DashboardWindow.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include <QTimer>
+#include <QtCharts/QChartGlobal>
 #include <QtCharts/QChartView>
 #include <QtCharts/QChart>
 #include <QtCharts/QBarSeries>
@@ -11,7 +12,7 @@
 #include <QtCharts/QPieSeries>
 #include <QListWidget>
 
-using namespace QtCharts;
+QT_CHARTS_USE_NAMESPACE
 #include "stock/StockPrediction.h"
 
 class SalesManager;


### PR DESCRIPTION
## Summary
- include `QChartGlobal` before other QtCharts headers
- replace `using namespace QtCharts` with `QT_CHARTS_USE_NAMESPACE`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687d9ae697848328bba601801a3866a6