### PR TITLE
Fix chart axis setup

### DIFF
--- a/src/dashboard/DashboardWindow.cpp
+++ b/src/dashboard/DashboardWindow.cpp
@@ -108,7 +108,8 @@ void DashboardWindow::refresh()
         chart->addSeries(series);
         auto *axis = new QBarCategoryAxis(chart);
         axis->append(categories);
-        chart->setAxisX(axis, series);
+        chart->addAxis(axis, Qt::AlignBottom);
+        series->attachAxis(axis);
         chart->createDefaultAxes();
     }
 


### PR DESCRIPTION
## Summary
- avoid deprecated `setAxisX` when building dashboard chart

## Testing
- `cmake --build . --target src/CMakeFiles/NieSApp.dir/dashboard/DashboardWindow.cpp.o -f src/CMakeFiles/NieSApp.dir/build.make VERBOSE=1`

------
https://chatgpt.com/codex/tasks/task_e_687d9da302d4832891c6d646e34570bf